### PR TITLE
Reflect our openshift configuration after the rename

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -160,17 +160,17 @@ $ dnf install certbot
 
 Run certbot in the root of this git repo.
 ```
-$ certbot certonly --config-dir cert/ --work-dir cert/ --logs-dir cert/ --manual --preferred-challenges dns --email ttomecek@redhat.com -d '*.logdetective.com' -d '*.logdetective.com' -d 'log-detective.com' -d 'logdetective.com'
+$ certbot certonly --config-dir cert/ --work-dir cert/ --logs-dir cert/ --manual --preferred-challenges dns --email ttomecek@redhat.com -d '*.log-detective.com' -d '*.logdetective.com' -d 'log-detective.com' -d 'logdetective.com'
 ```
 
 We will create one certificate file that will contain data for both
-logdetective.com and logdetective.com. With wildcards and naked. We need all
+log-detective.com and logdetective.com. With wildcards and naked. We need all
 these 4 entries to get https://log... and https://www... working.
 ```
 Please deploy a DNS TXT record under the name:
 ```
 
-Set those 2 TXT DNS entries for logdetective.com and logdetective.com
+Set those 2 TXT DNS entries for log-detective.com and logdetective.com
 
 Wait for those 2 entries to be up:
 ```
@@ -187,7 +187,7 @@ You can verify the newly created cert with `openssl` CLI. Here we check that bot
 $ openssl x509 -inform pem -noout -text -in 'cert/live/logdetective.com/fullchain.pem'
 ...
             X509v3 Subject Alternative Name:
-                DNS:logdetective.com, DNS:logdetective.com
+                DNS:log-detective.com, DNS:logdetective.com
 ```
 
 Once verified, you should delete those TXT DNS records.

--- a/openshift/log-detective.yaml
+++ b/openshift/log-detective.yaml
@@ -72,9 +72,9 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: logdetective-website
+  name: log-detective-website
 spec:
-  host: logdetective.com
+  host: log-detective.com
   to:
     kind: Service
     name: logdetective-website
@@ -87,9 +87,9 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: logdetective-website-www
+  name: log-detective-website-www
 spec:
-  host: www.logdetective.com
+  host: www.log-detective.com
   to:
     kind: Service
     name: logdetective-website

--- a/openshift/log-detective.yaml
+++ b/openshift/log-detective.yaml
@@ -50,8 +50,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
-status: {}
+      storage: 2Gi
 ---
 kind: Service
 apiVersion: v1

--- a/openshift/log-detective.yaml
+++ b/openshift/log-detective.yaml
@@ -73,7 +73,6 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: logdetective-website
-  namespace: communishift-logdetective
 spec:
   host: logdetective.com
   to:
@@ -89,7 +88,6 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: logdetective-website-www
-  namespace: communishift-logdetective
 spec:
   host: www.logdetective.com
   to:
@@ -105,7 +103,6 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: logdetective-website
-  namespace: communishift-logdetective
 spec:
   host: logdetective.com
   to:
@@ -121,7 +118,6 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: logdetective-website-www
-  namespace: communishift-logdetective
 spec:
   host: www.logdetective.com
   to:


### PR DESCRIPTION
All of these changes are now live. I had to revert a few rename changes because we still have the log-detective.com domain.

There was also a misconfiguration in the PVC. See commits for details.