### PR TITLE
Changed tarball folder name

### DIFF
--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -33,7 +33,7 @@ def make_tar(name: str, source: Path, destination: Path) -> Path:
     """
     tar_path = destination / name
     with tarfile.open(tar_path, "w:gz") as tar_f:
-        tar_f.add(source, arcname=name)
+        tar_f.add(source, arcname="results")
 
     return tar_path
 


### PR DESCRIPTION
Fix https://github.com/fedora-copr/logdetective-website/issues/165

Changed the folder inside the tarball to be called "results" instead of "results-<timestamp>.tar.gz"