### PR TITLE
Add server support to the backend

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           subdirectory: backend
           install_rpm_packages: |
-            python3-starlette
+            python3-starlette python3-requests
 
       - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ See README files for frontend and backend:
 - [frontend](frontend/README.md)
 - [backend](backend/README.md)
 
+### With [logdetective server](https://github.com/fedora-copr/logdetective)
+
+To be able to use parts of the website communicating with logdetective server you need to specify server url. To specify server url you need to add `SERVER_URL` variable into the `docker-compose.yaml`.
+
+Similar to this:
+```yaml
+...
+services:
+  backend:
+    ...
+    environment:
+      - SERVER_URL=http://192.168.0.1:8080
+```
+
+If you want to also run the logdetective server locally use docker compose on the [logdetective repository](https://github.com/fedora-copr/logdetective). And specify your local IP ("localhost" or 127.0.0.1 can't be used because of container networking).
+
 ## Deployment
 
 See [openshift/README](openshift/README.md)

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -9,6 +9,8 @@ REVIEWS_DIR = os.environ.get("REVIEWS_DIR", "/persistent/reviews")
 
 COPR_RESULT_TEMPLATE = "https://download.copr.fedorainfracloud.org" + \
                        "/results/{0}/{1}/srpm-builds/{2:08}"
+# logdetective server URL
+SERVER_URL = os.environ.get("SERVER_URL", "http://127.0.0.1:8000")
 
 
 class ProvidersEnum(StrEnum):


### PR DESCRIPTION
Add code to connect to the server and process it's output so that website is able to show this to the user.

Possible improvements:
- Easier way to set the environment variable to the docker-compose
- Better exception handling
- ~Add snippet log as separate server data so it could be correctly showed on the website~
- Add unit tests


I tried to found a better way than using local IP to connect two compose runs together. The issue is that docker-compose seems to be an isolated unit with no option to pass environment variable in or share one pod created by user.

![2024-12-02T16:18:04,547062822+01:00](https://github.com/user-attachments/assets/d8b8006c-7158-40ed-bdd6-d9cc2ce33cd7)
