### PR TITLE
openshift: enable running explain

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -108,7 +108,7 @@ Images are build and pushed with every new tag by a github action.
 Make sure you are using the correct OpenShift project
 
 ```
-oc project communishift-logdetective
+oc project communishift-log-detective
 ```
 
 If a Kubernetes/OpenShift configuration change needs to be applied,

--- a/openshift/log-detective.yaml
+++ b/openshift/log-detective.yaml
@@ -28,14 +28,16 @@ spec:
               mountPath: /persistent
           resources:
             requests:
-              memory: "400Mi"
+              memory: "800Mi"
               cpu: "50m"
             limits:
-              memory: "800Mi"
+              memory: "1600Mi"
               cpu: "500m"
           env:
             - name: SERVER_URL
               value: http://logdetective01.fedorainfracloud.org:8080
+          command: ["gunicorn"]
+          args: ["-k", "uvicorn.workers.UvicornWorker", "--certfile", "/persistent/letsencrypt/live/logdetective.com/cert.pem", "--keyfile", "/persistent/letsencrypt/live/log-detective.com/privkey.pem", "--ca-certs", "/persistent/letsencrypt/live/log-detective.com/fullchain.pem", "api:app", "-b", "0.0.0.0:8080", "--timeout", "1800", "--workers", "2"]
   replicas: 1
   strategy:
     type: Recreate
@@ -44,7 +46,6 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: persistent
   name: persistent


### PR DESCRIPTION
1. we were getting OOMkilled, so we doubled the memory requests

2. the default timeout is tiny - the analysis can easily run for one
   minute; hence setting gunicorn timeout to 30 minutes

these changes are already live