### PR TITLE
explain: update prompt description

### DIFF
--- a/frontend/src/app/prompt/core.cljs
+++ b/frontend/src/app/prompt/core.cljs
@@ -101,9 +101,7 @@
        :id "promptTextarea"
        :rows "3",
        :placeholder
-       (str "Either upload your failed build log as a file, "
-            "paste it contents as a text, or point to fully qualified URL "
-            "where it can be downloaded as a raw file.")
+       (str "Paste a link to your failed RPM build log.")
        :on-change on-change-prompt}]
      [:span
       {:class "input-group-addon btn btn-primary"

--- a/frontend/src/app/prompt/core.cljs
+++ b/frontend/src/app/prompt/core.cljs
@@ -214,30 +214,30 @@
       [:div {:class "py-4"}
        (prompt-form)]
 
-      [:div {:id "prompt-examples"}
-       [:button {:type "button"
-                 :class "btn btn-outline-secondary"
-                 :on-click on-click-example
-                 :data-prompt "TODO Example 1 prompt"}
-        "Example 1"]
+      ;;[:div {:id "prompt-examples"}
+      ;; [:button {:type "button"
+      ;;           :class "btn btn-outline-secondary"
+      ;;           :on-click on-click-example
+      ;;           :data-prompt "TODO Example 1 prompt"}
+      ;;  "Example 1"]
 
-       [:button {:type "button"
-                 :class "btn btn-outline-secondary"
-                 :on-click on-click-example
-                 :data-prompt "TODO Example 2 prompt"}
-        "Example 2"]
+      ;; [:button {:type "button"
+      ;;           :class "btn btn-outline-secondary"
+      ;;           :on-click on-click-example
+      ;;           :data-prompt "TODO Example 2 prompt"}
+      ;;  "Example 2"]
 
-       [:button {:type "button"
-                 :class "btn btn-outline-secondary"
-                 :on-click on-click-example
-                 :data-prompt "TODO Example 3 prompt"}
-        "Example 3"]
+      ;; [:button {:type "button"
+      ;;           :class "btn btn-outline-secondary"
+      ;;           :on-click on-click-example
+      ;;           :data-prompt "TODO Example 3 prompt"}
+      ;;  "Example 3"]
 
-       [:button {:type "button"
-                 :class "btn btn-outline-secondary"
-                 :on-click on-click-example
-                 :data-prompt "TODO Example 4 prompt"}
-        "Example 4"]]]]]
+      ;; [:button {:type "button"
+      ;;           :class "btn btn-outline-secondary"
+      ;;           :on-click on-click-example
+      ;;           :data-prompt "TODO Example 4 prompt"}
+      ;;  "Example 4"]]]]]
 
    [:div {:class "container" :id "about"}
     [:h2 {:class "text-center"} "About the project"]


### PR DESCRIPTION
we only accept a URL right now

also contains:

> explain: comment out example buttons
> not implemented yet, so let's hide them