### PR TITLE
Parametrizing Log Detective response timeouts

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -31,6 +31,8 @@ from src.constants import (
     FEEDBACK_DIR,
     REVIEWS_DIR,
     SERVER_URL,
+    LOGDETECTIVE_READ_TIMEOUT,
+    LOGDETECTIVE_CONNECT_TIMEOUT,
     BuildIdTitleEnum,
     ProvidersEnum,
 )
@@ -331,7 +333,12 @@ async def frontend_explain_post(request: Request):
     download_log_task = create_task(_download_log_content(log_url))
 
     try:
-        response = requests.post(server_url, headers=headers, data=json.dumps(data), timeout=1800)
+        # First value of `timeout` is for connection, second is for recieving the response
+        response = requests.post(
+            server_url,
+            headers=headers,
+            data=json.dumps(data),
+            timeout=(LOGDETECTIVE_CONNECT_TIMEOUT, LOGDETECTIVE_READ_TIMEOUT))
     except (requests.ConnectionError, requests.Timeout) as ex:
         raise HTTPException(
             status_code=408, detail=str(ex)

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -7,6 +7,11 @@ KOJI_BUILD_URL = "https://koji.fedoraproject.org/koji/buildinfo?buildID={0}"
 FEEDBACK_DIR = os.environ.get("FEEDBACK_DIR", "/persistent/results")
 REVIEWS_DIR = os.environ.get("REVIEWS_DIR", "/persistent/reviews")
 
+LOGDETECTIVE_READ_TIMEOUT = float(os.environ.get("LOGDETECTIVE_READ_TIMEOUT", 1800))
+# Set to slightly more than retransmission window of 3s from RFC2988
+# https://datatracker.ietf.org/doc/html/rfc2988
+LOGDETECTIVE_CONNECT_TIMEOUT = float(os.environ.get("LOGDETECTIVE_CONNECT_TIMEOUT", 3.07))
+
 COPR_RESULT_TEMPLATE = "https://download.copr.fedorainfracloud.org" + \
                        "/results/{0}/{1}/srpm-builds/{2:08}"
 # logdetective server URL

--- a/files/env
+++ b/files/env
@@ -1,3 +1,7 @@
 STORAGE_DIR=/persistent
 FEEDBACK_DIR=/persistent/results
 REVIEWS_DIR=/persistent/reviews
+LOGDETECTIVE_READ_TIMEOUT=1800
+# Set to slightly more than retransmission window of 3s from RFC2988
+# https://datatracker.ietf.org/doc/html/rfc2988
+LOGDETECTIVE_CONNECT_TIMEOUT=3.07


### PR DESCRIPTION
Both connection and read timeouts are now parametrized, with defaults in code and in the env file.