### PR TITLE
layout: Make header bar link to actual Log Detective code

### DIFF
--- a/frontend/public/layout.html
+++ b/frontend/public/layout.html
@@ -75,7 +75,7 @@
               <a
                 class="nav-link active"
                 aria-current="page"
-                href="https://github.com/fedora-copr/logdetective-website"
+                href="https://github.com/fedora-copr/logdetective"
               >
                 Code
               </a>
@@ -84,7 +84,7 @@
               <a
                 class="nav-link active"
                 aria-current="page"
-                href="https://github.com/fedora-copr/logdetective-website/issues"
+                href="https://github.com/fedora-copr/logdetective/issues"
               >
                 Issues
               </a>


### PR DESCRIPTION
Prior to this commit the header bar linked to the code and issues of this website itself, rather than the Log Detective code. While technically correct, this is confusing and doesn't match the user intentions.