### PR TITLE
backend: don't use the first snippet comment for all snippets

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -392,7 +392,7 @@ def _process_server_data(data):
     for snippet in r_data["snippets"]:
         reasoning.append({
             "snippet": snippet["text"],
-            "comment": r_data["snippets"][0]["explanation"]["text"],
+            "comment": snippet["explanation"]["text"],
         })
 
     try:


### PR DESCRIPTION
In the Reasoning seciton of the explanation page, we list multiple snippets. Their text is correct but we use the comment from the first snippet for all snippets.