### PR TITLE
Explain: print full log line with snippet body

### DIFF
--- a/frontend/src/app/prompt/core.cljs
+++ b/frontend/src/app/prompt/core.cljs
@@ -155,7 +155,9 @@
        :aria-labelledby heading-id
        :data-bs-parent accordion-id}
       [:div
-       {:class "accordion-body"} comment]]]))
+       {:class "accordion-body"}
+       [:code snippet]
+       comment]]]))
 
 (defn download []
   (let [name (-> @form :log :name)


### PR DESCRIPTION
This can help folks with triage a lot to see the full line when the
error value is usually at the end of the line.

This is a quick and dirty solution.

Addresses #209

Example:
![image](https://github.com/user-attachments/assets/3dcf3693-6e2e-43f9-acd0-624d7834fa1f)

It's kinda ugly but gets the job done IMO. I tried not to truncate the button but that just overflew outside of the window and was terrible.