### PR TITLE
Correct browser history for our explain page

### DIFF
--- a/frontend/src/app/helpers.cljs
+++ b/frontend/src/app/helpers.cljs
@@ -45,3 +45,8 @@
 
 (defn redirect [url]
   (set! (.-href (.-location js/window)) url))
+
+(defn change-url
+  "Change URL without a full page reload or redirect"
+  [url]
+  (.pushState (.-history js/window) nil nil url))

--- a/frontend/src/app/helpers.cljs
+++ b/frontend/src/app/helpers.cljs
@@ -42,3 +42,6 @@
 
 (defn safe [text]
   (.encode html-entities text))
+
+(defn redirect [url]
+  (set! (.-href (.-location js/window)) url))

--- a/frontend/src/app/homepage.cljs
+++ b/frontend/src/app/homepage.cljs
@@ -8,6 +8,7 @@
             [app.components.jumbotron :refer [render-error]]
             [app.helpers :refer
              [current-path
+              redirect
               local-storage-enabled
               local-storage-error
               remove-trailing-slash]]))
@@ -43,7 +44,7 @@
                  "#container" [(js/btoa (get @input-values :url))])
         url (str/join "/" (concat ["/contribute" source] (map str/trim params)))]
     (when (empty? @input-errors)
-      (set! (.-href (.-location js/window)) url))))
+      (redirect url))))
 
 (defn on-submit-upload [event]
   (.preventDefault event)

--- a/frontend/src/app/prompt/core.cljs
+++ b/frontend/src/app/prompt/core.cljs
@@ -4,7 +4,7 @@
    [malli.core :as m]
    [clojure.string :as str]
    [ajax.core :refer [POST]]
-   [app.helpers :refer [query-params-get]]
+   [app.helpers :refer [query-params-get change-url]]
    [app.components.jumbotron :refer
     [render-error
      loading-screen]]))
@@ -56,6 +56,7 @@
   (let [data {:prompt url}]
     (if (m/validate OutputSchema data)
       (do
+        (change-url (str "?url=" url))
         (reset! status "waiting")
         (POST "/frontend/explain/"
           :params data
@@ -273,7 +274,13 @@
                "the failure in simple words, with recommendations how to fix "
                "it. You won't need to open the logs at all."))]])
 
+(defn on-url-change []
+  (if (query-params-get "url")
+    (send (query-params-get "url"))
+    (reset! status nil)))
+
 (defn prompt []
+  (.addEventListener js/window "popstate" on-url-change)
   (let [query-url (query-params-get "url")]
     (cond
       (= @status "error")


### PR DESCRIPTION
Fix #210

This should fix the back and forward browser buttons on our explain page