### PR TITLE
Allowing submissions from koji flatpak builds

### DIFF
--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -166,7 +166,13 @@ class CoprProvider(RPMProvider):
 class KojiProvider(RPMProvider):
     koji_url = "https://koji.fedoraproject.org"
     # checkout.log - for dist-git repo cloning problems
-    logs_to_look_for = ["build.log", "root.log", "mock_output.log", "checkout.log"]
+    logs_to_look_for = [
+        "build.log",
+        "root.log",
+        "mock_output.log",
+        "checkout.log",
+        "flatpak.log",
+    ]
     koji_pkgs_url = "https://kojipkgs.fedoraproject.org/work"
 
     def __init__(self, build_or_task_id: int, arch: str) -> None:
@@ -253,7 +259,11 @@ class KojiProvider(RPMProvider):
         # if someone complains about, just reintroduce the if below
         # if self.task_info["arch"] != self.arch:
 
-        if self.task_info["method"] not in ("buildArch", "buildSRPMFromSCM"):
+        if self.task_info["method"] not in (
+            "buildArch",
+            "buildSRPMFromSCM",
+            "flatpakBuildArch",
+        ):
             # we could navigate to the right task, but let's be explicit in the meantime
             # let user input the proper task instead of us guessing
             raise HTTPException(

--- a/backend/tests/unit/test_fetcher.py
+++ b/backend/tests/unit/test_fetcher.py
@@ -132,7 +132,7 @@ class TestKojiProviderLogs:
         mock_task_info.return_value = request.getfixturevalue(f_task_dict)
         koji_provider = KojiProvider(123, "noarch")
         logs = koji_provider.fetch_logs()
-        assert len(logs) == 4
+        assert len(logs) == 5
         for log in logs:
             assert log["content"] == "LOG_CONTENT"
 


### PR DESCRIPTION
This doesn't resolve https://github.com/fedora-copr/logdetective/issues/244 but it does at least allow for uploads of failed flatpak build logs. 