### PR TITLE
Limiting memory allocation to java runtime

### DIFF
--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -15,4 +15,5 @@
 
  :dev-http {3000 "public"}
  :nrepl {:port 3333}
- :source-paths ["src"]}
+ :source-paths ["src"]
+ :jvm-opts ["-XX:MaxHeapSize=255m" "-XX:MaxDirectMemorySize=512m"]}


### PR DESCRIPTION
The options used [0] should put limits on both direct buffers and on heap. Together this should keep memory around 768MB.


[0] https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html

```
ID            NAME                              CPU %       MEM USAGE / LIMIT  MEM %       NET IO             BLOCK IO           PIDS        CPU TIME      AVG CPU %
5c8138af3d0c  log-detective-website_backend_1   0.16%       52.5MB / 67.1GB    0.08%       3.29kB / 1.048kB   98.3kB / 176.1kB   6           1.61788s      0.25%
3d8a7c2cdb66  log-detective-website_frontend_1  1.13%       779.3MB / 67.1GB   1.16%       57.09MB / 1.349MB  221.2kB / 54.62MB  125         1m45.860146s  16.35%

```