### PR TITLE
Tick checkbox as long as at least one snippet has description

### DIFF
--- a/frontend/src/app/contribute.cljs
+++ b/frontend/src/app/contribute.cljs
@@ -129,7 +129,7 @@
      "Create snippets by selecting them and clicking 'Add', then writing annotations")
 
     (instructions-item
-     (not-empty (:comment (first @snippets)))
+     (some not-empty (map :comment @snippets))
      "Describe what makes the snippets interesting")
 
     (instructions-item


### PR DESCRIPTION
Since we had issues when we were deleting previously selected snippets outright, this change instead loosens conditional to check if `any` snippet has it's description filled. 

Originally reported: https://github.com/fedora-copr/logdetective/issues/285 