### PR TITLE
Adding link to review of just submitted annotation

### DIFF
--- a/frontend/src/app/contribute.cljs
+++ b/frontend/src/app/contribute.cljs
@@ -41,7 +41,8 @@
      build-id
      build-id-title
      build-url
-     text-in-log-selected?]]
+     text-in-log-selected?
+     ok-status]]
    [app.contribute-events :refer
     [submit-form
      on-how-to-fix-textarea-change
@@ -67,7 +68,8 @@
              (:logs data))))
 
   (reset! error-title nil)
-  (reset! error-description nil))
+  (reset! error-description nil)
+  (reset! ok-status nil))
 
 (defn fetch-logs-backend []
   (let [url (remove-trailing-slash (str "/frontend" (current-path)))]
@@ -222,12 +224,17 @@
               :disabled (or (empty? @how-to-fix) (some empty (map :comment @snippets)))}
      "Submit"]]])
 
-(defn render-succeeded []
+(defn render-succeeded [ok-response]
   (render-jumbotron
    "succeeded"
    "Thank you!"
    "Successfully submitted, thank you for your contribution."
-   "..."
+   [:p
+    "You can review it here: "
+    [:a
+     {:href
+      (:review_url_website ok-response)}
+     (:review_url_website ok-response)]]
    [:a {:type "submit"
         :class "btn btn-primary btn-lg"
         :href "/"}
@@ -257,7 +264,7 @@
   ;;    The form data is being uploaded, but form stays in an editable state so
   ;;    we can recover (and e.g. fix the server-side validation errors).
   ;; "submitted" (status="submitted")
-  ;;    A separate "thank you" page.
+  ;;    A separate "thank you" page with URL to annotated log in review interface.
   ;; "error page" (status="error")
   ;;    A separate error page, e.g. for failed loading.
   (cond
@@ -265,7 +272,7 @@
     (render-error @error-title @error-description)
 
     (= @status "submitted")
-    (render-succeeded)
+    (render-succeeded @ok-status)
 
     @files
     (do

--- a/frontend/src/app/contribute_atoms.cljs
+++ b/frontend/src/app/contribute_atoms.cljs
@@ -18,3 +18,5 @@
 (def build-url (r/atom nil))
 
 (def text-in-log-selected? (r/atom nil))
+
+(def ok-status (r/atom nil))

--- a/frontend/src/app/contribute_events.cljs
+++ b/frontend/src/app/contribute_events.cljs
@@ -19,7 +19,8 @@
      status
      fas
      spec
-     container]]))
+     container
+     ok-status]]))
 
 (defn submit-form []
   (let [url (remove-trailing-slash (str "/frontend" (current-path)))
@@ -69,9 +70,8 @@
                          ;; validation errors
                          (reset! status nil))
 
-                       (= (:status data) "ok")
-                       (reset! status "submitted")
-
+                       (= (:status data) "ok") ((reset! status "submitted")
+                                                (reset! ok-status data))
                        :else nil))))))
 
 (defn on-how-to-fix-textarea-change [target]


### PR DESCRIPTION
Turns out we are already returning the link for review in our response. https://github.com/fedora-copr/logdetective-website/blob/main/backend/src/api.py#L252 