### PR TITLE
Moving to Fedora 42 as our base container image

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:42
 LABEL maintainer="copr-devel@lists.fedorahosted.org"
 
 RUN dnf -y update && \
@@ -9,10 +9,9 @@ RUN dnf -y update && \
                    net-tools \
                    iputils \
                    vim \
-                   mlocate \
+                   plocate \
                    git-core git-lfs \
                    sudo \
-                   python3-ipdb \
                    findutils \
     # The dependencies for this project
     && dnf -y install \

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:42
 LABEL maintainer="copr-devel@lists.fedorahosted.org"
 
 RUN dnf -y update && \
@@ -9,10 +9,9 @@ RUN dnf -y update && \
                    net-tools \
                    iputils \
                    vim \
-                   mlocate \
+                   plocate \
                    git-core git-lfs \
                    sudo \
-                   python3-ipdb \
                    findutils \
     # The dependencies for this project
     && dnf -y install \

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:42
 LABEL maintainer="copr-devel@lists.fedorahosted.org"
 
 ENV ENV=production
@@ -20,7 +20,7 @@ RUN npm install
 RUN npm install -g shadow-cljs@">=2.26.0 <3.0.0"
 RUN npx shadow-cljs release app
 
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:42
 LABEL maintainer="copr-devel@lists.fedorahosted.org"
 
 ENV ENV=production
@@ -39,17 +39,15 @@ RUN dnf -y install python3-fastapi \
                    python3-pip \
                    koji \
                    htop \
-                   btop \
                    make \
                    wget \
                    net-tools \
                    iputils \
                    vim \
-                   mlocate \
+                   plocate \
                    jq \
                    fpaste \
                    git \
-                   python3-ipdb \
                    findutils \
     && dnf clean all \
     && pip3 --no-cache-dir install datasets \


### PR DESCRIPTION
* Replacing mlocate with plocate as mlocate is no longer in repos
* Removing btop, since it's redundant with htop
* Removing python3-ipdb since we don't need a better python debugger

Resolves: #261 