### PR TITLE
Moving production configuration into file

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -58,6 +58,7 @@ RUN dnf -y install python3-fastapi \
 COPY --from=0 /src/frontend/public /src/frontend/public
 COPY --from=0 /src/backend /src/backend
 COPY --from=0 /src/files/compile_extraction_dataset.py /usr/bin/compile_extraction_dataset.py
+COPY --from=0 /src/files/gunicorn.conf.py /src/gunicorn.conf.py
 
 # According to the documentation, gunicorn is a valid production server
 # https://www.uvicorn.org/deployment/
@@ -65,4 +66,4 @@ WORKDIR /src/backend/src
 ENV PYTHONPATH="${PYTHONPATH}:/src/backend"
 
 # We should put this into a config file
-CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "--certfile", "/persistent/letsencrypt/live/logdetective.com/cert.pem", "--keyfile", "/persistent/letsencrypt/live/log-detective.com/privkey.pem", "--ca-certs", "/persistent/letsencrypt/live/log-detective.com/fullchain.pem", "api:app", "-b", "0.0.0.0:8080", "--max-requests", "50", "--max-requests-jitter", "5"]
+CMD ["gunicorn", "-c", "/src/gunicorn.conf.py", "api:app"]

--- a/files/gunicorn.conf.py
+++ b/files/gunicorn.conf.py
@@ -1,0 +1,14 @@
+# Configuration for production gunicorn server
+# pylint: skip-file
+import multiprocessing
+
+workers = multiprocessing.cpu_count() * 2
+worker_class = "uvicorn.workers.UvicornWorker"
+max_requests = 100
+max_requests_jitter = 10
+threads = multiprocessing.cpu_count() * 2
+bind = "0.0.0.0:8080"
+cerfile = "/persistent/letsencrypt/live/logdetective.com/cert.pem"
+keyfile = "/persistent/letsencrypt/live/log-detective.com/privkey.pem"
+ca_certs = "/persistent/letsencrypt/live/log-detective.com/fullchain.pem"
+timeout = 1800

--- a/openshift/log-detective.yaml
+++ b/openshift/log-detective.yaml
@@ -48,17 +48,9 @@ spec:
                   key: token
           command: ["gunicorn"]
           args: [
-            "-k",
-            "uvicorn.workers.UvicornWorker",
-            "--certfile", "/persistent/letsencrypt/live/log-detective.com/cert.pem",
-            "--keyfile", "/persistent/letsencrypt/live/log-detective.com/privkey.pem",
-            "--ca-certs", "/persistent/letsencrypt/live/log-detective.com/fullchain.pem",
-            "api:app",
-            "-b", "0.0.0.0:8080",
-            "--timeout", "1800",
-            "--workers", "2",
-            "--max-requests", "50",
-            "--max-requests-jitter", "5"]
+            "-c",
+           "/src/gunicorn.conf.py",
+           "api:app"]
   replicas: 1
   strategy:
     type: Recreate


### PR DESCRIPTION
Configuration for production server is now in a separate file. I've also explicitly set number of workers, increased number of requests and jitter. Where possible, the values were derived from https://docs.gunicorn.org/en/stable/settings.html#config-file 

Note: 
For production image we are pulling repo and then using it in the image, rather than getting the source from local dir. 
This means that this change will fail, if you your try to run production deployment before it is merged. Awkward, but reasonable workaround is replace step cloning the original repo with:

```
RUN git clone https://github.com/jpodivin/log-detective-website.git /sr && \
cd /src && \
git checkout -b gunicornconfig origin/gunicornconfig
```