### PR TITLE
Adapting website for new Log Detective API

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from http import HTTPStatus
 from pathlib import Path
 from typing import Optional
+from urllib import parse
 
 import requests
 
@@ -405,8 +406,14 @@ async def frontend_explain_post(request: Request) -> dict:
 
     :returns: {
         "explanation": str,
-        "reasoning": {"snippet": str, "comment": str},
-        "certainty": int,
+        "extracted_snippets": [
+            {
+                "snippet": str,
+                "source_file": str,
+                "line_number": int
+            },
+            ...
+        ],
         "log": {"name": str, "content": str}
     }
     """
@@ -414,13 +421,24 @@ async def frontend_explain_post(request: Request) -> dict:
     log_url = data["prompt"]
 
     LOGGER.info("Asking server to analyze log '%s'", log_url)
-    data = {"url": log_url}
+
+    file_name = Path(parse.urlparse(url=log_url).path).name
+
+    data = {
+        "files": [{"name": file_name, "url": log_url}],
+        "build_metadata": {
+            "specfile": None,
+            "last_patch": None,
+            "commentary": "",
+            "infra_status": None,
+        },
+    }
     headers = {"Content-Type": "application/json"}
 
     if LOG_DETECTIVE_TOKEN:
         headers["Authorization"] = f"Bearer {LOG_DETECTIVE_TOKEN}"
 
-    server_url = f"{SERVER_URL}/analyze/staged"
+    server_url = f"{SERVER_URL}/analyze"
 
     # download log_file when waiting for logdetective server processing
     download_log_task = create_task(_download_log_content(log_url))
@@ -470,39 +488,37 @@ def _process_server_data(data) -> dict:
     Return them in format:
     {
         "explanation": str,
-        "reasoning": {"snippet": str, "comment": str},
-        "certainty": int,
+        "extracted_snippets": [
+            {
+                "snippet": str,
+                "source_file": str,
+                "line_number": int
+            },
+            ...
+        ]
     }
     """
     try:
-        r_data = json.loads(data)
+        parsed_data = json.loads(data)
     except json.JSONDecodeError as ex:
         raise HTTPException(
             status_code=408, detail="Received invalid data from server"
         ) from ex
 
-    explanation = r_data["explanation"]["text"]
-    reasoning = []
-
-    for snippet in r_data["snippets"]:
-        reasoning.append(
+    explanation = parsed_data["explanation"]["text"]
+    extracted_snippets = []
+    for snippet in parsed_data["snippets"]:
+        extracted_snippets.append(
             {
                 "snippet": snippet["text"],
-                "comment": snippet["explanation"]["text"],
+                "source_file": snippet["source_file"],
+                "line_number": snippet["line_number"],
             }
         )
 
-    try:
-        certainty = int(r_data["response_certainty"])
-    except ValueError as ex:
-        raise HTTPException(
-            status_code=408, detail="Wrong certainty data received from the server"
-        ) from ex
-
     return {
         "explanation": explanation,
-        "reasoning": reasoning,
-        "certainty": certainty,
+        "extracted_snippets": extracted_snippets,
     }
 
 

--- a/frontend/public/css/prompt.css
+++ b/frontend/public/css/prompt.css
@@ -67,6 +67,12 @@ footer {
   margin-top: 25px;
 }
 
+.accordion-button {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+
 .accordion-button code {
   color: var(--bs-black);
   font-size: 13px;
@@ -86,4 +92,26 @@ footer {
 
 #prompt-examples button {
   margin-right: 10px;
+}
+
+.source-file {
+  color: black;
+  white-space: nowrap;
+}
+
+.line-number {
+  color: black;
+  padding-inline-end: 1em;
+}
+
+.truncated-snippet {
+  padding: 1em 1em;
+  color: grey;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.full-snippet {
+  white-space: pre-wrap;
 }

--- a/frontend/src/app/prompt/core.cljs
+++ b/frontend/src/app/prompt/core.cljs
@@ -22,13 +22,13 @@
 (def InputSchema
   [:map {:closed true}
    [:explanation :string]
-   [:certainty :int]
 
-   [:reasoning
+   [:extracted_snippets
     [:vector
      [:map
       [:snippet :string]
-      [:comment :string]]]]
+      [:source_file :string]
+      [:line_number :int]]]]
 
    [:log
     [:map
@@ -97,23 +97,8 @@
        :on-click #(send @prompt-value)}
       [:i {:class "fa-solid fa-play prompt-icon"}]]]]])
 
-(defn certainty-icon [percent]
-  (let [title (str "The AI is " percent "% certain of this response")]
-    (cond
-      (> percent 90)
-      [:i {:class "fa-regular fa-face-smile text-primary" :title title}]
-
-      (> percent 70)
-      [:i {:class "fa-regular fa-face-meh text-warning" :title title}]
-
-      :else
-      [:i {:class "fa-regular fa-face-frown-open text-danger" :title title}])))
-
 (defn left-column []
   [:div {:class "col-6", :id "left-column"}
-  ;; Rendering of certainty icon is disabled to comply with AIA
-  ;;  [:h2 {:class "float-end"}
-  ;;   (certainty-icon (:certainty @form))]
    [:h2 "Explanation"]
    (map (fn [x] [:p x])
         (-> @form :explanation (str/split #"\n")))
@@ -122,7 +107,7 @@
     {:class "container", :id "prompt"}
     (prompt-form)]])
 
-(defn reason [id snippet comment]
+(defn reason [id snippet source_file line_number]
   (let [accordion-id "#accordionExample"
         heading-id (str "heading-reason-" id)
         collapse-id (str "collapse-reason-" id)]
@@ -135,20 +120,27 @@
         :data-bs-target (str "#" collapse-id)
         :aria-expanded "false"
         :aria-controls collapse-id}
-       [:code {:class "text-truncate"} snippet]]]
+        [:span
+          {:class "source-file"}
+          source_file
+          ] " : "
+        [:span
+          {:class "line-number"}
+          line_number] " | "
+        [:span
+          {:class "truncated-snippet"}
+          snippet]]]
 
-     (if comment
       [:div
-        {:id collapse-id
-        :class "accordion-collapse collapse"
-        :aria-labelledby heading-id
-        :data-bs-parent accordion-id}
+        {
+          :id collapse-id
+          :class "accordion-collapse collapse"
+          :aria-labelledby heading-id
+          :data-bs-parent accordion-id}
         [:div
-        {:class "accordion-body"}
-        [:code snippet]
-        [:p comment]]]
-       nil
-      )]))
+          [:code {:class "full-snippet"} snippet]]
+        ]
+      ]))
 
 (defn download []
   (let [name (-> @form :log :name)
@@ -170,11 +162,11 @@
     [:i {:class "fa-solid fa-floppy-disk"}]
     " Full log"]
 
-   [:h2 "Reasoning"]
+   [:h2 "Extracted snippets"]
    [:div {:class "accordion accordion-flush" :id "accordionExample"}
     (map-indexed
-     (fn [i x] (reason i (:snippet x) (:comment x)))
-     (:reasoning @form))]])
+     (fn [i x] (reason i (:snippet x) (:source_file x) (:line_number x)))
+     (:extracted_snippets @form))]])
 
 (defn two-column-layout []
   [:div {:class "row" :id "content"}


### PR DESCRIPTION
The website can now send requests to new API and process responses. The format of the output has changed to follow new schema. Certainty was removed.

<img width="1699" height="1320" alt="Screenshot From 2026-04-23 16-32-51" src="https://github.com/user-attachments/assets/9cbde9f7-c35f-4831-a68d-6123cc655265" />
