### PR TITLE
Async API for /explain endpoint

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           subdirectory: backend
           install_rpm_packages: |
-            python3-starlette python3-requests python3-sentry-sdk+fastapi python3-regex
+            python3-starlette python3-requests python3-sentry-sdk+fastapi python3-regex python3-httpx
 
       - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+httpx

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ copr
 regex
 sentry-sdk[fastapi]
 datasets
+httpx

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,11 @@
+fastapi
+uvicorn[standard]
+gunicorn
+jinja2
+pydantic
+requests
+koji
+copr
+regex
+sentry-sdk[fastapi]
+datasets

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Optional
 from urllib import parse
 
-import requests
+import httpx
 
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
@@ -35,6 +35,7 @@ from src.constants import (
     SERVER_URL,
     LOGDETECTIVE_READ_TIMEOUT,
     LOGDETECTIVE_CONNECT_TIMEOUT,
+    LOGDETECTIVE_DEFAULT_TIMEOUT,
     BuildIdTitleEnum,
     ProvidersEnum,
     LOGGER_NAME,
@@ -183,7 +184,7 @@ def explain(request: Request, url: Optional[str] = None):
 
 @app.get("/frontend/contribute/copr/{build_id}/{chroot}")
 @app.get("/frontend/contribute/koji/{build_id}/{chroot}")
-def get_build_logs_with_chroot(
+async def get_build_logs_with_chroot(
     request: Request, build_id: int, chroot: str
 ) -> ContributeResponseSchema:
     provider_name = request.url.path.lstrip("/").split("/")[2]
@@ -200,45 +201,45 @@ def get_build_logs_with_chroot(
         build_id=build_id,
         build_id_title=build_title,
         build_url=build_url,
-        logs=provider.fetch_logs(),
-        spec_file=provider.fetch_spec_file(),
+        logs=await provider.fetch_logs(),
+        spec_file=await provider.fetch_spec_file(),
     )
 
 
 @app.get("/frontend/contribute/packit/{packit_id}")
-def get_packit_build_logs(packit_id: int) -> ContributeResponseSchema:
+async def get_packit_build_logs(packit_id: int) -> ContributeResponseSchema:
     provider = PackitProvider(packit_id)
     return ContributeResponseSchema(
         build_id=packit_id,
         build_id_title=BuildIdTitleEnum.packit,
-        build_url=provider.url,
-        logs=provider.fetch_logs(),
-        spec_file=provider.fetch_spec_file(),
+        build_url=await provider.get_url(),
+        logs=await provider.fetch_logs(),
+        spec_file=await provider.fetch_spec_file(),
     )
 
 
 @app.get("/frontend/contribute/url/{base64}")
-def get_build_logs_from_url(base64: str) -> ContributeResponseSchema:
+async def get_build_logs_from_url(base64: str) -> ContributeResponseSchema:
     build_url = b64decode(base64).decode("utf-8")
     provider = URLProvider(build_url)
     return ContributeResponseSchema(
         build_id=None,
         build_id_title=BuildIdTitleEnum.url,
         build_url=build_url,
-        logs=provider.fetch_logs(),
-        spec_file=provider.fetch_spec_file(),
+        logs=await provider.fetch_logs(),
+        spec_file=await provider.fetch_spec_file(),
     )
 
 
 @app.get("/frontend/contribute/container/{base64}")
-def get_logs_from_container(base64: str) -> ContributeResponseSchema:
+async def get_logs_from_container(base64: str) -> ContributeResponseSchema:
     build_url = b64decode(base64).decode("utf-8")
     provider = ContainerProvider(build_url)
     return ContributeResponseSchema(
         build_id=None,
         build_id_title=BuildIdTitleEnum.container,
         build_url=build_url,
-        logs=provider.fetch_logs(),
+        logs=await provider.fetch_logs(),
     )
 
 
@@ -444,24 +445,28 @@ async def frontend_explain_post(request: Request) -> dict:
     download_log_task = create_task(_download_log_content(log_url))
 
     try:
-        # First value of `timeout` is for connection, second is for recieving the response
-        response = requests.post(
-            server_url,
-            headers=headers,
-            data=json.dumps(data),
-            timeout=(LOGDETECTIVE_CONNECT_TIMEOUT, LOGDETECTIVE_READ_TIMEOUT),
-        )
-    except (requests.ConnectionError, requests.Timeout) as ex:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                server_url,
+                headers=headers,
+                json=data,
+                timeout=httpx.Timeout(
+                    LOGDETECTIVE_DEFAULT_TIMEOUT,
+                    connect=LOGDETECTIVE_CONNECT_TIMEOUT,
+                    read=LOGDETECTIVE_READ_TIMEOUT,
+                ),
+            )
+    except (httpx.ConnectError, httpx.TimeoutException) as ex:
         raise HTTPException(status_code=408, detail=str(ex)) from ex
 
     try:
         LOGGER.debug(
-            "headers: %s data: %s", response.request.headers, response.request.body
+            "headers: %s data: %s", response.request.headers, response.request.content
         )
         response.raise_for_status()
-    except requests.HTTPError as ex:
-        detail = f"{ex.response.status_code} {ex.response.reason}\n{ex.response.url}"
-        raise HTTPException(status_code=ex.response.status_code, detail=detail) from ex
+    except httpx.HTTPError as ex:
+        detail = f"{response.status_code} {response.reason_phrase}\n{response.url}"
+        raise HTTPException(status_code=response.status_code, detail=detail) from ex
 
     result = _process_server_data(response.content)
 
@@ -526,18 +531,18 @@ async def _download_log_content(url: str) -> str:
     """Download content of the log file and returns it."""
 
     try:
-        response = fetch_text(url, timeout=600)
+        response = await fetch_text(url, timeout=600)
     except (
-        requests.ConnectionError,
-        requests.Timeout,
-        requests.RequestException,
+        httpx.ConnectError,
+        httpx.TimeoutException,
+        httpx.RequestError,
     ) as ex:
         raise HTTPException(status_code=408, detail=str(ex)) from ex
     try:
         response.raise_for_status()
-    except requests.HTTPError as ex:
-        detail = f"{ex.response.status_code} {ex.response.reason}\n{ex.response.url}"
-        raise HTTPException(status_code=ex.response.status_code, detail=detail) from ex
+    except httpx.HTTPError as ex:
+        detail = f"{response.status_code} {response.reason_phrase}\n{response.url}"
+        raise HTTPException(status_code=response.status_code, detail=detail) from ex
 
     return response.text
 

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -14,6 +14,9 @@ LOGDETECTIVE_READ_TIMEOUT = float(os.environ.get("LOGDETECTIVE_READ_TIMEOUT", 18
 LOGDETECTIVE_CONNECT_TIMEOUT = float(
     os.environ.get("LOGDETECTIVE_CONNECT_TIMEOUT", 3.07)
 )
+LOGDETECTIVE_DEFAULT_TIMEOUT = float(
+    os.environ.get("LOGDETECTIVE_DEFAULT_TIMEOUT", 3.07)
+)
 
 COPR_RESULT_TEMPLATE = (
     "https://download.copr.fedorainfracloud.org" + "/results/{0}/{1}/srpm-builds/{2:08}"

--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -1,5 +1,4 @@
 import binascii
-import inspect
 import os
 import re
 import subprocess
@@ -31,31 +30,30 @@ def handle_errors(func):
     """
     Decorator to catch all client API and network issues and re-raise them as
     HTTPException to API which handles them.
-    Supports both sync and async functions.
     """
 
-    def _handle(ex):
-        if isinstance(
-            ex, (copr.v3.exceptions.CoprNoResultException, koji.GenericError)
-        ):
+    @wraps(func)
+    async def inner(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except HTTPException:
+            raise
+        except (copr.v3.exceptions.CoprNoResultException, koji.GenericError) as ex:
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST, detail=str(ex)
             ) from ex
-
-        if isinstance(ex, binascii.Error):
+        except binascii.Error as ex:
             detail = (
                 "Unable to decode a log URL from the base64 hash. "
                 "How did you get to this page?"
             )
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=detail) from ex
-
-        if isinstance(ex, httpx.HTTPStatusError):
+        except httpx.HTTPStatusError as ex:
             detail = f"{ex.response.status_code} {ex.response.reason_phrase}\n{ex.response.url}"
             raise HTTPException(
                 status_code=ex.response.status_code, detail=detail
             ) from ex
-
-        if isinstance(ex, subprocess.CalledProcessError):
+        except subprocess.CalledProcessError as ex:
             if "No such task" in str(ex.stderr):
                 raise HTTPException(
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -70,31 +68,7 @@ def handle_errors(func):
 
             raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR) from ex
 
-        raise ex
-
-    if inspect.iscoroutinefunction(func):
-
-        @wraps(func)
-        async def async_inner(*args, **kwargs):
-            try:
-                return await func(*args, **kwargs)
-            except HTTPException:
-                raise
-            except Exception as ex:
-                _handle(ex)
-
-        return async_inner
-
-    @wraps(func)
-    def sync_inner(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except HTTPException:
-            raise
-        except Exception as ex:
-            _handle(ex)
-
-    return sync_inner
+    return inner
 
 
 class Provider(ABC):

--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -1,17 +1,17 @@
 import binascii
+import inspect
 import os
 import re
 import subprocess
 from abc import ABC, abstractmethod
-from functools import cached_property
+from functools import cached_property, wraps
 from http import HTTPStatus
 from pathlib import Path
 from typing import Optional
-from urllib.error import HTTPError
 
 import copr.v3
 import koji
-import requests
+import httpx
 from fastapi import HTTPException
 
 from src.constants import COPR_RESULT_TEMPLATE, LOGGER_NAME
@@ -30,42 +30,38 @@ LOGGER = get_logger(LOGGER_NAME)
 def handle_errors(func):
     """
     Decorator to catch all client API and network issues and re-raise them as
-    HTTPException to API which handles them
+    HTTPException to API which handles them.
+    Supports both sync and async functions.
     """
 
-    def inner(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-
-        except copr.v3.exceptions.CoprNoResultException or koji.GenericError as ex:
+    def _handle(ex):
+        if isinstance(
+            ex, (copr.v3.exceptions.CoprNoResultException, koji.GenericError)
+        ):
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST, detail=str(ex)
             ) from ex
 
-        except binascii.Error as ex:
+        if isinstance(ex, binascii.Error):
             detail = (
                 "Unable to decode a log URL from the base64 hash. "
                 "How did you get to this page?"
             )
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=detail) from ex
 
-        except requests.HTTPError as ex:
-            detail = (
-                f"{ex.response.status_code} {ex.response.reason}\n{ex.response.url}"
-            )
+        if isinstance(ex, httpx.HTTPStatusError):
+            detail = f"{ex.response.status_code} {ex.response.reason_phrase}\n{ex.response.url}"
             raise HTTPException(
                 status_code=ex.response.status_code, detail=detail
             ) from ex
 
-        except subprocess.CalledProcessError as ex:
-            # When koji can't find the task.
+        if isinstance(ex, subprocess.CalledProcessError):
             if "No such task" in str(ex.stderr):
                 raise HTTPException(
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                     detail=ex.stderr.decode(),
                 ) from ex
 
-            # Everything else
             if os.environ.get("ENV") != "production":
                 raise HTTPException(
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -74,12 +70,36 @@ def handle_errors(func):
 
             raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR) from ex
 
-    return inner
+        raise ex
+
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        async def async_inner(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except HTTPException:
+                raise
+            except Exception as ex:
+                _handle(ex)
+
+        return async_inner
+
+    @wraps(func)
+    def sync_inner(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPException:
+            raise
+        except Exception as ex:
+            _handle(ex)
+
+    return sync_inner
 
 
 class Provider(ABC):
     @abstractmethod
-    def fetch_logs(self) -> list[dict[str, str]]:
+    async def fetch_logs(self) -> list[dict[str, str]]:
         """
         Fetches logs from a provider with name and content.
 
@@ -95,7 +115,7 @@ class RPMProvider(Provider):
     """
 
     @abstractmethod
-    def fetch_spec_file(self) -> dict[str, str]:
+    async def fetch_spec_file(self) -> Optional[dict[str, str]]:
         """
         Fetches spec file with its content and name.
 
@@ -114,7 +134,7 @@ class CoprProvider(RPMProvider):
         self.client = copr.v3.Client({"copr_url": self.copr_url})
 
     @handle_errors
-    def fetch_logs(self) -> list[dict[str, str]]:
+    async def fetch_logs(self) -> list[dict[str, str]]:
         log_names = ["builder-live.log.gz", "backend.log.gz"]
 
         if self.chroot == "srpm-builds":
@@ -137,7 +157,7 @@ class CoprProvider(RPMProvider):
         logs = []
         for name in log_names:
             url = "{}/{}".format(baseurl, name)
-            response = fetch_text(url)
+            response = await fetch_text(url)
             response.raise_for_status()
             logs.append(
                 {
@@ -148,7 +168,7 @@ class CoprProvider(RPMProvider):
         return logs
 
     @handle_errors
-    def fetch_spec_file(self) -> Optional[dict[str, str]]:
+    async def fetch_spec_file(self) -> Optional[dict[str, str]]:
         build = self.client.build_proxy.get(self.build_id)
         name = build.source_package["name"]
         if self.chroot == "srpm-builds":
@@ -162,7 +182,7 @@ class CoprProvider(RPMProvider):
             baseurl = build_chroot.result_url
 
         spec_name = f"{name}.spec"
-        response = fetch_text(f"{baseurl}/{spec_name}")
+        response = await fetch_text(f"{baseurl}/{spec_name}")
         if response.status_code == 404:
             return None
         response.raise_for_status()
@@ -294,7 +314,7 @@ class KojiProvider(RPMProvider):
         return logs
 
     @handle_errors
-    def fetch_logs(self) -> list[dict[str, str]]:
+    async def fetch_logs(self) -> list[dict[str, str]]:
         logs = self._fetch_task_logs_from_task_id()
 
         if not logs:
@@ -326,21 +346,22 @@ class KojiProvider(RPMProvider):
 
         return {"name": fst_spec_file.name, "content": read_text_file(fst_spec_file)}
 
-    def _fetch_spec_file_from_task_id(self) -> Optional[dict[str, str]]:
+    async def _fetch_spec_file_from_task_id(self) -> Optional[dict[str, str]]:
         with get_temporary_dir() as temp_dir:
             srpm_url = self._get_srpm_url_from_task()
             if not srpm_url:
                 return None
-            resp = requests.get(srpm_url)
-            if not resp.ok:
-                LOGGER.error(
-                    "SRPM %s for task %s not accessible: %s (%s)",
-                    srpm_url,
-                    self.task_id,
-                    resp.status_code,
-                    resp.reason,
-                )
-                return None
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(srpm_url)
+                if not resp.is_success:
+                    LOGGER.error(
+                        "SRPM %s for task %s not accessible: %s (%s)",
+                        srpm_url,
+                        self.task_id,
+                        resp.status_code,
+                        resp.reason_phrase,
+                    )
+                    return None
 
             destination = Path(f"{temp_dir}/{srpm_url.split('/')[-1]}")
             with open(destination, "wb") as srpm_f:
@@ -349,7 +370,7 @@ class KojiProvider(RPMProvider):
             return self._get_spec_file_content_from_srpm(destination, temp_dir)
 
     @handle_errors
-    def fetch_spec_file(self) -> Optional[dict[str, str]]:
+    async def fetch_spec_file(self) -> Optional[dict[str, str]]:
         """
         Fetch spec file from dist-git if possible.
 
@@ -358,17 +379,17 @@ class KojiProvider(RPMProvider):
         request_url = self.get_task_request_url()
         # request_url is not a link but rather a relative path to the SRPM
         if request_url is None:
-            return self._fetch_spec_file_from_task_id()
+            return await self._fetch_spec_file_from_task_id()
         package_name = re.findall(r"/rpms/(.+)\.git", request_url)[0]
         commit_hash = re.findall(r"\.git#(.+)$", request_url)[0]
         spec_url = (
             "https://src.fedoraproject.org/rpms/"
             f"{package_name}/raw/{commit_hash}/f/{package_name}.spec"
         )
-        response = fetch_text(spec_url)
+        response = await fetch_text(spec_url)
         try:
             response.raise_for_status()
-        except HTTPError as exc:
+        except httpx.HTTPStatusError as exc:
             LOGGER.error(
                 "No spec file found in koji for task #%s and arch %s.Reason: %s",
                 self.task_id,
@@ -392,33 +413,31 @@ class PackitProvider(RPMProvider):
     """
 
     packit_api_url = "https://prod.packit.dev/api"
+    _provider: Optional[CoprProvider | KojiProvider] = None
 
     def __init__(self, packit_id: int) -> None:
         self.packit_id = packit_id
         self.copr_url = f"{self.packit_api_url}/copr-builds/{self.packit_id}"
         self.koji_url = f"{self.packit_api_url}/koji-builds/{self.packit_id}"
-        self._provider = None
 
-    @property
-    def provider(self):
-        """
-        Cached so that we don't send HTTP requests for every call
-        """
-        if not self._provider:
-            self._provider = self._get_correct_provider()
+    async def _get_provider(self) -> CoprProvider | KojiProvider:
+        if self._provider:
+            return self._provider
+        self._provider = await self._resolve_provider()
         return self._provider
 
-    def _get_correct_provider(self) -> CoprProvider | KojiProvider:
-        resp = requests.get(self.copr_url)
-        if resp.ok:
-            build = resp.json()
-            return CoprProvider(build["build_id"], build["chroot"])
+    async def _resolve_provider(self) -> CoprProvider | KojiProvider:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(self.copr_url)
+            if resp.is_success:
+                build = resp.json()
+                return CoprProvider(build["build_id"], build["chroot"])
 
-        resp = requests.get(self.koji_url)
-        if not resp.ok:
-            raise FetchError(
-                f"Couldn't find any build logs for Packit ID #{self.packit_id}."
-            )
+            resp = await client.get(self.koji_url)
+            if not resp.is_success:
+                raise FetchError(
+                    f"Couldn't find any build logs for Packit ID #{self.packit_id}."
+                )
 
         build = resp.json()
         task_id = build["task_id"]
@@ -431,16 +450,18 @@ class PackitProvider(RPMProvider):
         return KojiProvider(task_id, arch)
 
     @handle_errors
-    def fetch_logs(self) -> list[dict[str, str]]:
-        return self.provider.fetch_logs()
+    async def fetch_logs(self) -> list[dict[str, str]]:
+        provider = await self._get_provider()
+        return await provider.fetch_logs()
 
     @handle_errors
-    def fetch_spec_file(self) -> dict[str, str]:
-        return self.provider.fetch_spec_file()
+    async def fetch_spec_file(self) -> Optional[dict[str, str]]:
+        provider = await self._get_provider()
+        return await provider.fetch_spec_file()
 
-    @property
-    def url(self):
-        if isinstance(self.provider, CoprProvider):
+    async def get_url(self):
+        provider = await self._get_provider()
+        if isinstance(provider, CoprProvider):
             _url = "https://dashboard.packit.dev/results/copr-builds/{0}"
         else:
             _url = "https://dashboard.packit.dev/results/koji-builds/{0}"
@@ -452,10 +473,10 @@ class URLProvider(RPMProvider):
         self.url = url
 
     @handle_errors
-    def fetch_logs(self) -> list[dict[str, str]]:
+    async def fetch_logs(self) -> list[dict[str, str]]:
         # TODO Can we recognize a directory listing and show _all_ logs?
         #  also this will allow us to fetch spec files
-        response = fetch_text(self.url)
+        response = await fetch_text(self.url)
         response.raise_for_status()
         if "text/plain" not in response.headers["Content-Type"]:
             raise FetchError(
@@ -469,7 +490,7 @@ class URLProvider(RPMProvider):
         ]
 
     @handle_errors
-    def fetch_spec_file(self) -> dict[str, str]:
+    async def fetch_spec_file(self) -> Optional[dict[str, str]]:
         # FIXME: Please implement me!
         #  raise NotImplementedError("Please implement me!")
         return None  # type: ignore
@@ -484,9 +505,9 @@ class ContainerProvider(Provider):
         self.url = url
 
     @handle_errors
-    def fetch_logs(self) -> list[dict[str, str]]:
+    async def fetch_logs(self) -> list[dict[str, str]]:
         # TODO: c&p from url provider for now, integrate with containers better later on
-        response = fetch_text(self.url)
+        response = await fetch_text(self.url)
         response.raise_for_status()
         if "text/plain" not in response.headers["Content-Type"]:
             raise FetchError(

--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
-import requests
+import httpx
 import sentry_sdk
 
 from src.schema import (
@@ -153,19 +153,20 @@ def read_text_file(path: Path | str) -> str:
         return fp.read()
 
 
-def fetch_text(url: str, **kwargs) -> requests.Response:
+async def fetch_text(url: str, **kwargs) -> httpx.Response:
     """
     Fetch text content from URL with consistent UTF-8 encoding.
 
     Args:
         url: The URL to fetch
-        **kwargs: Additional arguments passed to requests.get()
+        **kwargs: Additional arguments passed to AsyncClient.get()
 
     Returns:
-        requests.Response with encoding set to UTF-8
+        httpx.Response with encoding set to UTF-8
     """
-    response = requests.get(url, **kwargs)
-    response.encoding = "utf-8"
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url, **kwargs)
+        response.encoding = "utf-8"
     return response
 
 

--- a/backend/tests/spells.py
+++ b/backend/tests/spells.py
@@ -1,12 +1,5 @@
 """Lyney would approve this :magic:"""
 
-import responses
-
-
-def mock_multiple_responses(url, logs):
-    for name, content in logs.items():
-        responses.add(responses.GET, f"{url}/{name}", body=content, status=200)
-
 
 def sort_by_name(item):
     return item["name"]

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -2,18 +2,268 @@
 Test the API endpoints.
 """
 
+import json
 import os
+from base64 import b64encode
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import httpx
 
 from src.api import app
-from fastapi.testclient import TestClient
 
-client = TestClient(app)
+FAKE_LOG_CONTENT = "mock build log content"
+FAKE_SPEC = {"name": "test.spec", "content": "spec content"}
+
+FAKE_SERVER_RESPONSE = json.dumps(
+    {
+        "explanation": {"text": "The build failed due to missing dependency."},
+        "snippets": [
+            {
+                "text": "error: package not found",
+                "source_file": "build.log",
+                "line_number": 42,
+            }
+        ],
+    }
+).encode()
+
+RealAsyncClient = httpx.AsyncClient
+
+
+class TestContributeEndpoints:
+    @patch("src.api.CoprProvider")
+    async def test_contribute_copr(self, mock_cls, tmp_path):
+        os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")
+        mock_provider = mock_cls.return_value
+        mock_provider.fetch_logs = AsyncMock(
+            return_value=[{"name": "build.log", "content": FAKE_LOG_CONTENT}]
+        )
+        mock_provider.fetch_spec_file = AsyncMock(return_value=FAKE_SPEC)
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.get("/frontend/contribute/copr/123/fedora-39-x86_64")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["build_id"] == 123
+        assert data["build_id_title"] == "Copr build"
+        assert "copr.fedorainfracloud.org" in data["build_url"]
+        assert len(data["logs"]) == 1
+        assert data["spec_file"]["name"] == "test.spec"
+
+    @patch("src.api.KojiProvider")
+    async def test_contribute_koji(self, mock_cls, tmp_path):
+        os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")
+        mock_provider = mock_cls.return_value
+        mock_provider.fetch_logs = AsyncMock(
+            return_value=[{"name": "build.log", "content": FAKE_LOG_CONTENT}]
+        )
+        mock_provider.fetch_spec_file = AsyncMock(return_value=None)
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.get("/frontend/contribute/koji/456/x86_64")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["build_id"] == 456
+        assert data["build_id_title"] == "Koji build"
+        assert "koji.fedoraproject.org" in data["build_url"]
+
+    @patch("src.api.PackitProvider")
+    async def test_contribute_packit(self, mock_cls, tmp_path):
+        os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")
+        mock_provider = mock_cls.return_value
+        mock_provider.fetch_logs = AsyncMock(
+            return_value=[{"name": "build.log", "content": FAKE_LOG_CONTENT}]
+        )
+        mock_provider.fetch_spec_file = AsyncMock(return_value=None)
+        mock_provider.get_url = AsyncMock(
+            return_value="https://dashboard.packit.dev/results/copr-builds/789"
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.get("/frontend/contribute/packit/789")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["build_id"] == 789
+        assert data["build_id_title"] == "Packit build"
+        assert "packit.dev" in data["build_url"]
+
+    @patch("src.api.URLProvider")
+    async def test_contribute_url(self, mock_cls, tmp_path):
+        os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")
+        url = "https://example.com/build.log"
+        b64 = b64encode(url.encode()).decode()
+        mock_provider = mock_cls.return_value
+        mock_provider.fetch_logs = AsyncMock(
+            return_value=[{"name": "Log file", "content": FAKE_LOG_CONTENT}]
+        )
+        mock_provider.fetch_spec_file = AsyncMock(return_value=None)
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.get(f"/frontend/contribute/url/{b64}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["build_url"] == url
+        assert data["build_id_title"] == "URL"
+
+    @patch("src.api.ContainerProvider")
+    async def test_contribute_container(self, mock_cls, tmp_path):
+        os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")
+        url = "https://example.com/container.log"
+        b64 = b64encode(url.encode()).decode()
+        mock_provider = mock_cls.return_value
+        mock_provider.fetch_logs = AsyncMock(
+            return_value=[{"name": "Container log", "content": FAKE_LOG_CONTENT}]
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.get(f"/frontend/contribute/container/{b64}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["build_url"] == url
+        assert data["build_id_title"] == "Container log"
+        assert len(data["logs"]) == 1
+
+
+class TestExplainEndpoint:
+    @patch("src.api._download_log_content", new_callable=AsyncMock)
+    @patch("src.api.httpx.AsyncClient")
+    async def test_explain_success(self, mock_client_cls, mock_download):
+        mock_download.return_value = FAKE_LOG_CONTENT
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = FAKE_SERVER_RESPONSE
+        mock_response.raise_for_status = MagicMock()
+        mock_response.request = MagicMock(headers={}, content=b"")
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = httpx.ASGITransport(app=app)
+        async with RealAsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/frontend/explain/",
+                json={"prompt": "https://example.com/build.log"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "explanation" in data
+        assert "extracted_snippets" in data
+        assert "log" in data
+        assert data["log"]["content"] == FAKE_LOG_CONTENT
+
+    @patch("src.api._download_log_content", new_callable=AsyncMock)
+    @patch("src.api.httpx.AsyncClient")
+    async def test_explain_server_timeout(self, mock_client_cls, mock_download):
+        mock_download.return_value = FAKE_LOG_CONTENT
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = httpx.ASGITransport(app=app)
+        async with RealAsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/frontend/explain/",
+                json={"prompt": "https://example.com/build.log"},
+            )
+
+        assert resp.status_code == 408
+
+    @patch("src.api._download_log_content", new_callable=AsyncMock)
+    @patch("src.api.httpx.AsyncClient")
+    async def test_explain_server_connect_error(self, mock_client_cls, mock_download):
+        mock_download.return_value = FAKE_LOG_CONTENT
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("connection refused")
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = httpx.ASGITransport(app=app)
+        async with RealAsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/frontend/explain/",
+                json={"prompt": "https://example.com/build.log"},
+            )
+
+        assert resp.status_code == 408
+
+    @patch("src.api._download_log_content", new_callable=AsyncMock)
+    @patch("src.api.httpx.AsyncClient")
+    async def test_explain_server_500(self, mock_client_cls, mock_download):
+        mock_download.return_value = FAKE_LOG_CONTENT
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.reason_phrase = "Internal Server Error"
+        mock_response.url = "http://127.0.0.1:8000/analyze"
+        mock_response.request = MagicMock(headers={}, content=b"")
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Server Error",
+                request=httpx.Request("POST", "http://127.0.0.1:8000/analyze"),
+                response=httpx.Response(500),
+            )
+        )
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        transport = httpx.ASGITransport(app=app)
+        async with RealAsyncClient(
+            transport=transport, base_url="http://test"
+        ) as client:
+            resp = await client.post(
+                "/frontend/explain/",
+                json={"prompt": "https://example.com/build.log"},
+            )
+
+        assert resp.status_code == 500
 
 
 def test_our_server_url(tmp_path):
-    """
-    Test that the server URL is properly set in the response.
-    """
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
     os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")
     data = {
         "username": "FAS:me",

--- a/backend/tests/unit/test_fetcher.py
+++ b/backend/tests/unit/test_fetcher.py
@@ -1,14 +1,35 @@
 import koji
 import pytest
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
 
-import responses
+import httpx
 from copr.v3 import BuildProxy, BuildChrootProxy
 
 from src.constants import COPR_RESULT_TEMPLATE
 from src.exceptions import FetchError
-from src.fetcher import CoprProvider, KojiProvider, URLProvider, PackitProvider
-from tests.spells import mock_multiple_responses, sort_by_name
+from src.fetcher import (
+    CoprProvider,
+    KojiProvider,
+    URLProvider,
+    PackitProvider,
+    ContainerProvider,
+)
+from tests.spells import sort_by_name
+
+
+def _mock_fetch_text(url_to_response: dict[str, tuple[str, int]]):
+    """Create an AsyncMock for fetch_text that returns httpx.Response objects
+    based on URL matching."""
+
+    async def _fake_fetch_text(url, **kwargs):
+        body, status_code = url_to_response[url]
+        return httpx.Response(
+            status_code=status_code,
+            text=body,
+            request=httpx.Request("GET", url),
+        )
+
+    return _fake_fetch_text
 
 
 class TestCoprProvider:
@@ -22,10 +43,9 @@ class TestCoprProvider:
             pytest.param("fedora-39_x86_64", None),
         ],
     )
-    @responses.activate
     @patch.object(BuildProxy, "get")
     @patch.object(BuildChrootProxy, "get")
-    def test_fetch_copr_logs(
+    async def test_fetch_copr_logs(
         self,
         mock_build_chroot_proxy,
         mock_build_proxy,
@@ -40,14 +60,16 @@ class TestCoprProvider:
         )
 
         logs = copr_srpm_logs if chroot == "srpm-builds" else copr_chroot_logs
-        if baseurl:
-            mock_multiple_responses(baseurl, logs)
 
         provider = CoprProvider(123, chroot)
         if not baseurl:
             with pytest.raises(FetchError):
-                provider.fetch_logs()
+                await provider.fetch_logs()
             return
+
+        url_map = {
+            f"{baseurl}/{name}": (content, 200) for name, content in logs.items()
+        }
 
         expected_result = sorted(
             [
@@ -56,7 +78,9 @@ class TestCoprProvider:
             ],
             key=sort_by_name,
         )
-        assert expected_result == sorted(provider.fetch_logs(), key=sort_by_name)
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            result = await provider.fetch_logs()
+        assert expected_result == sorted(result, key=sort_by_name)
 
     @pytest.mark.parametrize(
         "chroot, baseurl",
@@ -67,10 +91,9 @@ class TestCoprProvider:
             ),
         ],
     )
-    @responses.activate
     @patch.object(BuildProxy, "get")
     @patch.object(BuildChrootProxy, "get")
-    def test_fetch_copr_spec(
+    async def test_fetch_copr_spec(
         self, mock_build_chroot_proxy, mock_build_proxy, chroot, baseurl, fake_spec_file
     ):
         mock_build_chroot_proxy.return_value = MagicMock(result_url=baseurl)
@@ -83,28 +106,22 @@ class TestCoprProvider:
         )
 
         spec_name = f"{projectname}.spec"
-        responses.add(
-            responses.GET, url=f"{baseurl}/{spec_name}", body=fake_spec_file, status=200
-        )
+        url_map = {f"{baseurl}/{spec_name}": (fake_spec_file, 200)}
 
-        assert {"name": spec_name, "content": fake_spec_file} == CoprProvider(
-            123, chroot
-        ).fetch_spec_file()
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            result = await CoprProvider(123, chroot).fetch_spec_file()
+        assert {"name": spec_name, "content": fake_spec_file} == result
 
-        responses.add(
-            responses.GET,
-            url=f"{baseurl}/{spec_name}",
-            json={"error": "some error msg"},
-            status=404,
-        )
+        url_map_404 = {f"{baseurl}/{spec_name}": ("", 404)}
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map_404)):
+            result = await CoprProvider(123, chroot).fetch_spec_file()
+        assert result is None
 
-        assert CoprProvider(123, chroot).fetch_spec_file() is None
-
-    @responses.activate
     @patch.object(BuildProxy, "get")
     @patch.object(BuildChrootProxy, "get")
-    def test_fetch_copr_logs_with_utf8(self, mock_build_chroot_proxy, mock_build_proxy):
-        # UTF-8 content in logs should be correctly decoded
+    async def test_fetch_copr_logs_with_utf8(
+        self, mock_build_chroot_proxy, mock_build_proxy
+    ):
         baseurl = "https://copr.example.com/results"
         chroot = "fedora-39-x86_64"
         czech_log = "Chyba: závislost 'žluťoučký-balíček' nebyla nalezena"
@@ -114,17 +131,14 @@ class TestCoprProvider:
             ownername="owner", project_dirname="project", id=123
         )
 
-        for log_name in ["builder-live.log.gz", "backend.log.gz", "build.log.gz"]:
-            responses.add(
-                responses.GET,
-                url=f"{baseurl}/{log_name}",
-                body=czech_log.encode("utf-8"),
-                status=200,
-                content_type="text/plain",
-            )
+        url_map = {
+            f"{baseurl}/{name}": (czech_log, 200)
+            for name in ["builder-live.log.gz", "backend.log.gz", "build.log.gz"]
+        }
 
         provider = CoprProvider(123, chroot)
-        logs = provider.fetch_logs()
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            logs = await provider.fetch_logs()
 
         for log in logs:
             assert log["content"] == czech_log
@@ -132,29 +146,24 @@ class TestCoprProvider:
 
 
 class TestURLProvider:
-    @responses.activate
-    def test_fetch_url_logs(self):
+    async def test_fetch_url_logs(self):
         url = "https://www.fake.lol"
         provider = URLProvider(url)
-        responses.add(responses.GET, url=url, body="text")
-        assert provider.fetch_logs() == [{"name": "Log file", "content": "text"}]
+        url_map = {url: ("text", 200)}
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            result = await provider.fetch_logs()
+        assert result == [{"name": "Log file", "content": "text"}]
 
-    def test_fetch_url_spec(self):
-        assert URLProvider("https://www.fake.lol").fetch_spec_file() is None
+    async def test_fetch_url_spec(self):
+        assert await URLProvider("https://www.fake.lol").fetch_spec_file() is None
 
-    @responses.activate
-    def test_fetch_url_logs_with_utf8(self):
-        # UTF-8 content should be correctly decoded even without charset header
+    async def test_fetch_url_logs_with_utf8(self):
         url = "https://www.fake.lol/log.txt"
         czech_content = "Chyba: balíček nebyl nalezen\nŘešení: přidejte repozitář"
         provider = URLProvider(url)
-        responses.add(
-            responses.GET,
-            url=url,
-            body=czech_content.encode("utf-8"),
-            content_type="text/plain",  # no charset
-        )
-        logs = provider.fetch_logs()
+        url_map = {url: (czech_content, 200)}
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            logs = await provider.fetch_logs()
         assert logs[0]["content"] == czech_content
 
 
@@ -169,24 +178,25 @@ class TestKojiProviderLogs:
     )
     @patch.object(koji, "ClientSession")
     @patch.object(KojiProvider, "task_info", new_callable=PropertyMock)
-    def test_get_logs(self, mock_task_info, mock_client_session, f_task_dict, request):
+    async def test_get_logs(
+        self, mock_task_info, mock_client_session, f_task_dict, request
+    ):
         mock_client_session.return_value = MagicMock(
             getBuild=MagicMock(side_effect=koji.GenericError),
             downloadTaskOutput=MagicMock(return_value="LOG_CONTENT"),
         )
         mock_task_info.return_value = request.getfixturevalue(f_task_dict)
         koji_provider = KojiProvider(123, "noarch")
-        logs = koji_provider.fetch_logs()
+        logs = await koji_provider.fetch_logs()
         assert len(logs) == 5
         for log in logs:
             assert log["content"] == "LOG_CONTENT"
 
     @patch.object(koji, "ClientSession")
     @patch.object(KojiProvider, "task_info", new_callable=PropertyMock)
-    def test_get_logs_decodes_bytes(
+    async def test_get_logs_decodes_bytes(
         self, mock_task_info, mock_client_session, srpm_task_dict
     ):
-        # Koji API returns bytes - ensure they are decoded as UTF-8
         czech_log = "Chyba při kompilaci: žádný takový soubor"
         mock_client_session.return_value = MagicMock(
             getBuild=MagicMock(side_effect=koji.GenericError),
@@ -194,7 +204,7 @@ class TestKojiProviderLogs:
         )
         mock_task_info.return_value = srpm_task_dict
         koji_provider = KojiProvider(123, "noarch")
-        logs = koji_provider.fetch_logs()
+        logs = await koji_provider.fetch_logs()
         for log in logs:
             assert log["content"] == czech_log
             assert isinstance(log["content"], str)
@@ -232,8 +242,7 @@ class TestKojiProviderLogs:
 
     @patch.object(KojiProvider, "get_task_request_url")
     @patch.object(koji, "ClientSession")
-    @responses.activate
-    def test_fetch_spec_file_from_url(
+    async def test_fetch_spec_file_from_url(
         self, mock_client_session, mock_get_task_request_url, fake_spec_file
     ):
         mock_client_session.return_value = MagicMock(
@@ -243,14 +252,16 @@ class TestKojiProviderLogs:
             "git+https://src.fedoraproject.org/rpms/copr-frontend.git#dbcd207"
         )
         spec_url = "https://src.fedoraproject.org/rpms/copr-frontend/raw/dbcd207/f/copr-frontend.spec"  # pylint: disable=line-too-long
-        responses.add(responses.GET, url=spec_url, body=fake_spec_file, status=200)
+        url_map = {spec_url: (fake_spec_file, 200)}
         expected = {"name": "copr-frontend.spec", "content": fake_spec_file}
-        assert expected == KojiProvider(123, "noarch").fetch_spec_file()
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            result = await KojiProvider(123, "noarch").fetch_spec_file()
+        assert expected == result
 
-    @patch.object(KojiProvider, "_fetch_spec_file_from_task_id")
+    @patch.object(KojiProvider, "_fetch_spec_file_from_task_id", new_callable=AsyncMock)
     @patch.object(KojiProvider, "get_task_request_url")
     @patch.object(koji, "ClientSession")
-    def test_fetch_spec_file_from_task_id(
+    async def test_fetch_spec_file_from_task_id(
         self,
         mock_client_session,
         mock_get_task_request_url,
@@ -263,12 +274,13 @@ class TestKojiProviderLogs:
         mock_get_task_request_url.return_value = None
         expected = {"name": "copr-fronend.spec", "content": fake_spec_file}
         mock_fetch_spec_file_from_task_id.return_value = expected
-        assert expected == KojiProvider(123, "noarch").fetch_spec_file()
+        result = await KojiProvider(123, "noarch").fetch_spec_file()
+        assert expected == result
 
-    @patch.object(KojiProvider, "_fetch_spec_file_from_task_id")
+    @patch.object(KojiProvider, "_fetch_spec_file_from_task_id", new_callable=AsyncMock)
     @patch.object(KojiProvider, "get_task_request_url")
     @patch.object(koji, "ClientSession")
-    def test_fetch_spec_file_from_task_id_none(
+    async def test_fetch_spec_file_from_task_id_none(
         self,
         mock_client_session,
         mock_get_task_request_url,
@@ -280,7 +292,8 @@ class TestKojiProviderLogs:
         )
         mock_get_task_request_url.return_value = None
         mock_fetch_spec_file_from_task_id.return_value = None
-        assert KojiProvider(123, "noarch").fetch_spec_file() is None
+        koji_result = await KojiProvider(123, "noarch").fetch_spec_file()
+        assert koji_result is None
 
     @patch.object(koji, "ClientSession")
     def test_build_id_to_task_id(
@@ -300,92 +313,183 @@ class TestPackitProvider:
     packit_id = 123
     packit_provider = PackitProvider(packit_id)
 
-    @responses.activate
     @patch.object(BuildProxy, "get")
     @patch.object(BuildChrootProxy, "get")
-    def test_fetch_logs_with_utf8_via_copr(
+    async def test_fetch_logs_with_utf8_via_copr(
         self, mock_build_chroot_proxy, mock_build_proxy
     ):
-        # packit -> Copr delegation should preserve UTF-8 content
         build_id = 456
         chroot = "fedora-39-x86_64"
         baseurl = "https://copr.example.com/results"
         czech_log = "Sestavení selhalo: chybí závislost"
-
-        responses.add(
-            responses.GET,
-            url=self.packit_provider.copr_url,
-            status=200,
-            json={"build_id": build_id, "chroot": chroot},
-        )
 
         mock_build_chroot_proxy.return_value = MagicMock(result_url=baseurl)
         mock_build_proxy.return_value = MagicMock(
             ownername="owner", project_dirname="project", id=build_id
         )
 
-        for log_name in ["builder-live.log.gz", "backend.log.gz", "build.log.gz"]:
-            responses.add(
-                responses.GET,
-                url=f"{baseurl}/{log_name}",
-                body=czech_log.encode("utf-8"),
-                status=200,
-                content_type="text/plain",
+        url_map = {
+            f"{baseurl}/{name}": (czech_log, 200)
+            for name in ["builder-live.log.gz", "backend.log.gz", "build.log.gz"]
+        }
+
+        def _transport_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"build_id": build_id, "chroot": chroot},
             )
 
-        logs = self.packit_provider.fetch_logs()
+        transport = httpx.MockTransport(_transport_handler)
+
+        with patch(
+            "src.fetcher.httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=transport),
+        ):
+            with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+                provider = PackitProvider(self.packit_id)
+                logs = await provider.fetch_logs()
+
         for log in logs:
             assert log["content"] == czech_log
 
-    @responses.activate
-    def test_get_correct_provider_with_copr(self):
+    async def test_resolve_provider_with_copr(self):
         build_id = 456
         chroot = "fedora-39-x86_64"
 
-        responses.add(
-            responses.GET,
-            url=self.packit_provider.copr_url,
-            status=200,
-            json={"build_id": build_id, "chroot": chroot},
-        )
+        def _handler(request: httpx.Request) -> httpx.Response:
+            if "copr-builds" in str(request.url):
+                return httpx.Response(
+                    200, json={"build_id": build_id, "chroot": chroot}
+                )
+            return httpx.Response(404)
 
-        correct_provider = self.packit_provider._get_correct_provider()
+        transport = httpx.MockTransport(_handler)
+        provider = PackitProvider(self.packit_id)
+
+        with patch(
+            "src.fetcher.httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=transport),
+        ):
+            correct_provider = await provider._resolve_provider()
 
         assert isinstance(correct_provider, CoprProvider)
         assert correct_provider.build_id == build_id
         assert correct_provider.chroot == chroot
 
-    @responses.activate
     @patch.object(koji, "ClientSession")
-    @patch("src.fetcher.KojiProvider", autospec=True)
-    def test_get_correct_provider_with_koji(
-        self, mock_koji_provider, mock_client_session
-    ):
+    async def test_resolve_provider_with_koji(self, mock_client_session):
         task_id = 456
         arch = "x86_64"
 
-        responses.add(responses.GET, url=self.packit_provider.copr_url, status=404)
-        responses.add(
-            responses.GET,
-            url=self.packit_provider.koji_url,
-            status=200,
-            json={"task_id": task_id},
+        mock_client_session.return_value = MagicMock(
+            getBuild=MagicMock(side_effect=koji.GenericError),
+            getTaskInfo=MagicMock(return_value={"arch": arch}),
         )
 
-        instance = mock_koji_provider.return_value
-        instance.return_value = None
+        def _handler(request: httpx.Request) -> httpx.Response:
+            if "copr-builds" in str(request.url):
+                return httpx.Response(404)
+            if "koji-builds" in str(request.url):
+                return httpx.Response(200, json={"task_id": task_id})
+            return httpx.Response(404)
 
-        mock_client_session = MagicMock()
-        mock_client_session.getTaskInfo.return_value = {"arch": arch}
+        transport = httpx.MockTransport(_handler)
+        provider = PackitProvider(self.packit_id)
 
-        correct_provider = self.packit_provider._get_correct_provider()
+        with patch(
+            "src.fetcher.httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=transport),
+        ):
+            correct_provider = await provider._resolve_provider()
 
         assert isinstance(correct_provider, KojiProvider)
 
-    @responses.activate
-    def test_get_correct_provider_with_no_provider(self):
-        responses.add(responses.GET, url=self.packit_provider.koji_url, status=404)
-        responses.add(responses.GET, url=self.packit_provider.copr_url, status=404)
+    async def test_resolve_provider_with_no_provider(self):
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
 
-        with pytest.raises(FetchError):
-            self.packit_provider._get_correct_provider()
+        transport = httpx.MockTransport(_handler)
+        provider = PackitProvider(self.packit_id)
+
+        with patch(
+            "src.fetcher.httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=transport),
+        ):
+            with pytest.raises(FetchError):
+                await provider._resolve_provider()
+
+    async def test_get_url_copr(self):
+        mock_copr = MagicMock(spec=CoprProvider)
+        provider = PackitProvider(self.packit_id)
+        with patch.object(
+            provider, "_get_provider", new=AsyncMock(return_value=mock_copr)
+        ):
+            url = await provider.get_url()
+        assert (
+            url == f"https://dashboard.packit.dev/results/copr-builds/{self.packit_id}"
+        )
+
+    async def test_get_url_koji(self):
+        mock_koji = MagicMock(spec=KojiProvider)
+        provider = PackitProvider(self.packit_id)
+        with patch.object(
+            provider, "_get_provider", new=AsyncMock(return_value=mock_koji)
+        ):
+            url = await provider.get_url()
+        assert (
+            url == f"https://dashboard.packit.dev/results/koji-builds/{self.packit_id}"
+        )
+
+
+class TestContainerProvider:
+    async def test_fetch_logs(self):
+        url = "https://example.com/container.log"
+        content = "container build output"
+
+        async def _fake_fetch_text(u, **kwargs):
+            return httpx.Response(
+                200,
+                text=content,
+                headers={"Content-Type": "text/plain"},
+                request=httpx.Request("GET", u),
+            )
+
+        provider = ContainerProvider(url)
+        with patch("src.fetcher.fetch_text", side_effect=_fake_fetch_text):
+            result = await provider.fetch_logs()
+        assert result == [{"name": "Container log", "content": content}]
+
+    async def test_fetch_logs_non_text_content_type(self):
+        url = "https://example.com/page.html"
+
+        async def _fake_fetch_text(u, **kwargs):
+            return httpx.Response(
+                200,
+                text="<html></html>",
+                headers={"Content-Type": "text/html"},
+                request=httpx.Request("GET", u),
+            )
+
+        provider = ContainerProvider(url)
+        with patch("src.fetcher.fetch_text", side_effect=_fake_fetch_text):
+            with pytest.raises(FetchError):
+                await provider.fetch_logs()
+
+    async def test_fetch_logs_http_error(self):
+        url = "https://example.com/missing.log"
+
+        async def _fake_fetch_text(u, **kwargs):
+            return httpx.Response(
+                500,
+                text="Internal Server Error",
+                headers={"Content-Type": "text/plain"},
+                request=httpx.Request("GET", u),
+            )
+
+        provider = ContainerProvider(url)
+        with patch("src.fetcher.fetch_text", side_effect=_fake_fetch_text):
+            from fastapi import HTTPException
+
+            with pytest.raises(HTTPException) as exc_info:
+                await provider.fetch_logs()
+            assert exc_info.value.status_code == 500

--- a/backend/tests/unit/test_handle_errors.py
+++ b/backend/tests/unit/test_handle_errors.py
@@ -1,0 +1,156 @@
+import binascii
+import subprocess
+from http import HTTPStatus
+from unittest.mock import patch
+
+import copr.v3
+import httpx
+import koji
+import pytest
+from fastapi import HTTPException
+
+from src.fetcher import handle_errors
+
+
+class TestHandleErrorsAsync:
+    async def test_httpx_status_error(self):
+        @handle_errors
+        async def failing():
+            response = httpx.Response(
+                502,
+                request=httpx.Request("GET", "https://example.com/log"),
+            )
+            raise httpx.HTTPStatusError(
+                "Bad Gateway", request=response.request, response=response
+            )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == 502
+        assert "502" in exc_info.value.detail
+        assert "example.com/log" in exc_info.value.detail
+
+    async def test_copr_no_result_exception(self):
+        @handle_errors
+        async def failing():
+            raise copr.v3.exceptions.CoprNoResultException("build not found")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+        assert "build not found" in exc_info.value.detail
+
+    async def test_koji_generic_error(self):
+        @handle_errors
+        async def failing():
+            raise koji.GenericError("invalid task")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+        assert "invalid task" in exc_info.value.detail
+
+    async def test_binascii_error(self):
+        @handle_errors
+        async def failing():
+            raise binascii.Error("Invalid base64")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == HTTPStatus.NOT_FOUND
+        assert "base64" in exc_info.value.detail
+
+    async def test_called_process_error_no_such_task(self):
+        @handle_errors
+        async def failing():
+            raise subprocess.CalledProcessError(
+                1, "cmd", output=b"", stderr=b"No such task: 999"
+            )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert "No such task" in exc_info.value.detail
+
+    @patch.dict("os.environ", {"ENV": "devel"})
+    async def test_called_process_error_non_production(self):
+        @handle_errors
+        async def failing():
+            raise subprocess.CalledProcessError(1, "cmd", output=b"out", stderr=b"err")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert "stdout" in exc_info.value.detail
+        assert "stderr" in exc_info.value.detail
+
+    @patch.dict("os.environ", {"ENV": "production"})
+    async def test_called_process_error_production(self):
+        @handle_errors
+        async def failing():
+            raise subprocess.CalledProcessError(1, "cmd", output=b"out", stderr=b"err")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert exc_info.value.detail == "Internal Server Error"
+
+    async def test_http_exception_passthrough(self):
+        @handle_errors
+        async def failing():
+            raise HTTPException(status_code=418, detail="I'm a teapot")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await failing()
+        assert exc_info.value.status_code == 418
+        assert exc_info.value.detail == "I'm a teapot"
+
+    async def test_unknown_exception_reraised(self):
+        @handle_errors
+        async def failing():
+            raise RuntimeError("unexpected")
+
+        with pytest.raises(RuntimeError, match="unexpected"):
+            await failing()
+
+    async def test_success_returns_value(self):
+        @handle_errors
+        async def succeeding():
+            return "ok"
+
+        assert await succeeding() == "ok"
+
+
+class TestHandleErrorsSync:
+    def test_binascii_error(self):
+        @handle_errors
+        def failing():
+            raise binascii.Error("bad input")
+
+        with pytest.raises(HTTPException) as exc_info:
+            failing()
+        assert exc_info.value.status_code == HTTPStatus.NOT_FOUND
+
+    def test_koji_generic_error(self):
+        @handle_errors
+        def failing():
+            raise koji.GenericError("bad task")
+
+        with pytest.raises(HTTPException) as exc_info:
+            failing()
+        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+
+    def test_success_returns_value(self):
+        @handle_errors
+        def succeeding():
+            return 42
+
+        assert succeeding() == 42
+
+    def test_unknown_exception_reraised(self):
+        @handle_errors
+        def failing():
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError, match="nope"):
+            failing()

--- a/backend/tests/unit/test_handle_errors.py
+++ b/backend/tests/unit/test_handle_errors.py
@@ -119,38 +119,3 @@ class TestHandleErrorsAsync:
             return "ok"
 
         assert await succeeding() == "ok"
-
-
-class TestHandleErrorsSync:
-    def test_binascii_error(self):
-        @handle_errors
-        def failing():
-            raise binascii.Error("bad input")
-
-        with pytest.raises(HTTPException) as exc_info:
-            failing()
-        assert exc_info.value.status_code == HTTPStatus.NOT_FOUND
-
-    def test_koji_generic_error(self):
-        @handle_errors
-        def failing():
-            raise koji.GenericError("bad task")
-
-        with pytest.raises(HTTPException) as exc_info:
-            failing()
-        assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
-
-    def test_success_returns_value(self):
-        @handle_errors
-        def succeeding():
-            return 42
-
-        assert succeeding() == 42
-
-    def test_unknown_exception_reraised(self):
-        @handle_errors
-        def failing():
-            raise ValueError("nope")
-
-        with pytest.raises(ValueError, match="nope"):
-            failing()

--- a/backend/tests/unit/test_spells.py
+++ b/backend/tests/unit/test_spells.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-import responses
+import httpx
 from src.constants import DEFAULT_ROBOTS
 from src.spells import (
     ensure_text,
@@ -36,23 +36,27 @@ class TestEnsureText:
 
 
 class TestFetchText:
-    @responses.activate
-    def test_encoding_set_to_utf8(self):
+    async def test_encoding_set_to_utf8(self):
         """Response encoding should be set to UTF-8."""
         url = "http://example.com/log.txt"
-        # server returns UTF-8 content but doesn't specify charset
-        responses.add(
-            responses.GET,
-            url,
-            body="Příliš žluťoučký kůň".encode("utf-8"),
-            status=200,
-            content_type="text/plain",  # no charset specified
-        )
+        czech_text = "Příliš žluťoučký kůň"
 
-        response = fetch_text(url)
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=czech_text.encode("utf-8"),
+                headers={"content-type": "text/plain"},
+            )
+
+        transport = httpx.MockTransport(_handler)
+        with patch(
+            "src.spells.httpx.AsyncClient",
+            return_value=httpx.AsyncClient(transport=transport),
+        ):
+            response = await fetch_text(url)
 
         assert response.encoding == "utf-8"
-        assert response.text == "Příliš žluťoučký kůň"
+        assert response.text == czech_text
 
 
 class TestJsonFileIO:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -24,4 +24,5 @@ RUN dnf -y update && \
                    python3-copr \
                    python3-sentry-sdk+fastapi \
                    python3-regex \
+                   python3-httpx \
     && dnf clean all

--- a/docker/backend/Dockerfile.tests
+++ b/docker/backend/Dockerfile.tests
@@ -1,1 +1,1 @@
-RUN dnf install -y python3-pytest python3-responses python3-httpx && dnf clean all
+RUN dnf install -y python3-pytest python3-pytest-asyncio python3-httpx && dnf clean all

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -52,6 +52,7 @@ RUN dnf -y install python3-fastapi \
                    python3-sentry-sdk+fastapi \
                    python3-regex \
                    rsync \
+                   python3-httpx \
     && dnf clean all \
     && pip3 --no-cache-dir install datasets \
     && mkdir -p /src/{frontend,backend,cleaning_logs}


### PR DESCRIPTION
The call to Log Detective server used to be blocking. This had a high chance of causing problems, if something overwhelmed our workers, and that happened a lot.

With this change we shouldn't have the problem anymore. Also, the requirements are now duplicated in requirements.txt files, just to make building local venvs for testing a bit easier.