### PR TITLE
Use a pre-made archive in /download

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -1,6 +1,5 @@
 import json
 import os
-import tempfile
 import uuid
 from asyncio import create_task, gather
 from base64 import b64decode
@@ -24,7 +23,6 @@ from fastapi.responses import (
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
-from starlette.background import BackgroundTask
 from starlette.exceptions import HTTPException
 
 from src.constants import (
@@ -60,7 +58,6 @@ from src.schema import (
     schema_inp_to_out,
 )
 from src.spells import (
-    make_tar,
     find_file_by_name,
     get_logger,
     start_sentry,
@@ -703,34 +700,31 @@ def download_results():
     """
     Download all results we have as a tar.gz archive.
 
-    We create a temporary directory and store the archive in there.
-    After the client browser gets the whole file, we delete our temp
-    file and directory using the cleanup() method as a background task.
-
-    This function was rewritten from an async implementation that stopped working
-    (probably after an update to fastapi and starlette).
-    https://github.com/fedora-copr/log-detective-website/issues/157
+    The archive is pre-built daily by the create-archive CronJob and stored at
+    /persistent/results-YYYY-MM-DD.tar.gz. This endpoint just serves the most
+    recent one directly, avoiding a long blocking tar creation on each request.
     """
     if not FEEDBACK_DIR:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="No data found")
 
-    tmp_dir = Path(tempfile.mkdtemp())
-    tar_name = f"results-{int(datetime.now().timestamp())}.tar.gz"
-    tar_path = make_tar(tar_name, [Path(FEEDBACK_DIR), Path(REVIEWS_DIR)], tmp_dir)
+    storage_dir = Path(FEEDBACK_DIR).parent
+    archives = sorted(
+        [f for f in storage_dir.glob("results-*-*-*.tar.gz") if f.is_file()],
+        reverse=True,
+    )
+    if not archives:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail="No archive available yet, please try again later",
+        )
 
-    LOGGER.info("Starting download of the annotated dataset.")
-
-    def cleanup():
-        os.unlink(tar_path)
-        os.rmdir(tmp_dir)
+    tar_path = archives[0]
+    LOGGER.info("Starting download of the annotated dataset: %s", tar_path.name)
 
     # https://fastapi.tiangolo.com/advanced/custom-response/?h=fileresponse#fileresponse
-    # https://fastapi.tiangolo.com/reference/background/?h=background
     return FileResponse(
         tar_path,
-        filename=tar_name,
-        media_type="application/x-tar",
-        background=BackgroundTask(cleanup),
+        filename=tar_path.name,
     )
 
 

--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -6,7 +6,6 @@ import json
 import logging
 import os
 import shutil
-import tarfile
 import tempfile
 from contextlib import contextmanager
 from functools import lru_cache
@@ -41,26 +40,6 @@ def get_temporary_dir() -> Iterator[Path]:
         yield temp_dir
     finally:
         shutil.rmtree(temp_dir)
-
-
-def make_tar(name: str, sources: list[Path], destination: Path) -> Path:
-    """
-    Make tar from source path.
-
-    Args:
-        name: Name of the tar file
-        sources: Sources to be tarred
-        destination: Folder where to put tar file
-
-    Returns:
-        Path where to find a tar file.
-    """
-    tar_path = destination / name
-    with tarfile.open(tar_path, "w:gz") as tar_f:
-        for source in sources:
-            tar_f.add(source, arcname=f"results/{source.name}")
-
-    return tar_path
 
 
 def find_file_by_name(name: str, path: Path) -> Optional[Path]:

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -60,6 +60,7 @@ RUN dnf -y install python3-fastapi \
 COPY --from=0 /src/frontend/public /src/frontend/public
 COPY --from=0 /src/backend /src/backend
 COPY --from=0 /src/files/compile_extraction_dataset.py /usr/bin/compile_extraction_dataset.py
+COPY --from=0 /src/files/create_archive.py /usr/bin/create_archive.py
 COPY --from=0 /src/files/gunicorn.conf.py /src/gunicorn.conf.py
 COPY --from=0 /src/files/cleaning_logs /src/cleaning_logs
 

--- a/files/create_archive.py
+++ b/files/create_archive.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Create a dated tar.gz archive of all feedback and review data in STORAGE_DIR.
+Intended to be run daily via a Kubernetes CronJob.
+"""
+
+import os
+import tarfile
+from datetime import date
+from pathlib import Path
+
+FEEDBACK_DIR = Path(os.environ.get("FEEDBACK_DIR", "/persistent/results"))
+REVIEWS_DIR = Path(os.environ.get("REVIEWS_DIR", "/persistent/reviews"))
+
+
+def make_tar(name: str, sources: list[Path], destination: Path) -> Path:
+    """
+    Make tar from source path.
+
+    Args:
+        name: Name of the tar file
+        sources: Sources to be tarred
+        destination: Folder where to put tar file
+
+    Returns:
+        Path where to find a tar file.
+    """
+    tmp_path = destination / f"tmp-{name}"
+    tar_path = destination / name
+    with tarfile.open(tmp_path, "w:gz") as tar_f:
+        for source in sources:
+            if source.exists():
+                tar_f.add(source, arcname=f"results/{source.name}")
+            else:
+                print(f"{source} not found, skipping this source.")
+    tmp_path.rename(tar_path)
+    return tar_path
+
+
+def main():
+    """Create a dated tar.gz archive of feedback and review data, removing any older ones."""
+    storage_dir = FEEDBACK_DIR.parent
+    tar_name = f"results-{date.today().isoformat()}.tar.gz"
+    tar_path = make_tar(tar_name, [FEEDBACK_DIR, REVIEWS_DIR], storage_dir)
+    print(f"Archive created: {tar_path}")
+
+    for old in storage_dir.glob("results-*-*-*.tar.gz"):
+        if old != tar_path:
+            old.unlink()
+            print(f"Removed old archive: {old}")
+
+
+if __name__ == "__main__":
+    main()

--- a/openshift/dataset-cron.yaml
+++ b/openshift/dataset-cron.yaml
@@ -34,3 +34,44 @@ spec:
                 memory: "550Mi"
                 cpu: "250m"
           restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-archive
+spec:
+  schedule: "45 23 * * *"
+  concurrencyPolicy: "Replace"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            parent: "cronjob-create-archive"
+          name: create-archive
+        spec:
+          volumes:
+            - name: persistent
+              persistentVolumeClaim:
+                claimName: persistent
+          containers:
+          - name: create-archive
+            image: quay.io/sclorg/python-313-c10s:latest
+            imagePullPolicy: Always
+            command: ["python3", "/usr/bin/create_archive.py"]
+            volumeMounts:
+              - name: persistent
+                mountPath: /persistent
+            env:
+            - name: FEEDBACK_DIR
+              value: /persistent/results
+            - name: REVIEWS_DIR
+              value: /persistent/reviews
+            resources:
+              requests:
+                memory: "200Mi"
+                cpu: "100m"
+              limits:
+                memory: "500Mi"
+                cpu: "500m"
+          restartPolicy: OnFailure


### PR DESCRIPTION
- this is to avoid hitting timeouts
- archive is created every day at 23:45 (UTC)
- older copies get removed upon successful creation

Note: Container build CI job will keep failing until the `files/create_archive.py` is merged into main.