### PR TITLE
Centralized HTTP client

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from asyncio import create_task, gather
 from base64 import b64decode
+from contextlib import asynccontextmanager
 from datetime import datetime
 from http import HTTPStatus
 from pathlib import Path
@@ -71,6 +72,7 @@ from src.spells import (
 )
 from src.store import Storator3000
 from src.exceptions import NoDataFound
+from src.client import get_http_client
 
 LOGGER = get_logger(LOGGER_NAME)
 
@@ -80,8 +82,18 @@ if start_sentry():
 else:
     LOGGER.warning("Sentry was not configured for this deployment.")
 
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Manage application-wide resources."""
+    _app.state.http_client = get_http_client()
+    yield
+    await _app.state.http_client.aclose()
+
+
 app = FastAPI(
     title="Log Detective Website",
+    lifespan=lifespan,
     contact={
         "name": "Log Detective developers",
         "url": "https://github.com/fedora-copr/logdetective-website",
@@ -202,7 +214,7 @@ async def get_build_logs_with_chroot(
 ) -> ContributeResponseSchema:
     provider_name = request.url.path.lstrip("/").split("/")[2]
     prov_kls = CoprProvider if provider_name == ProvidersEnum.copr else KojiProvider
-    provider = prov_kls(build_id, chroot)
+    provider = prov_kls(build_id, chroot, http_client=app.state.http_client)
     if provider_name == ProvidersEnum.copr:
         build_title = BuildIdTitleEnum.copr
         build_url = COPR_BUILD_URL.format(build_id)
@@ -221,7 +233,7 @@ async def get_build_logs_with_chroot(
 
 @app.get("/frontend/contribute/packit/{packit_id}")
 async def get_packit_build_logs(packit_id: int) -> ContributeResponseSchema:
-    provider = PackitProvider(packit_id)
+    provider = PackitProvider(packit_id, http_client=app.state.http_client)
     return ContributeResponseSchema(
         build_id=packit_id,
         build_id_title=BuildIdTitleEnum.packit,
@@ -234,7 +246,7 @@ async def get_packit_build_logs(packit_id: int) -> ContributeResponseSchema:
 @app.get("/frontend/contribute/url/{base64}")
 async def get_build_logs_from_url(base64: str) -> ContributeResponseSchema:
     build_url = b64decode(base64).decode("utf-8")
-    provider = URLProvider(build_url)
+    provider = URLProvider(build_url, http_client=app.state.http_client)
     return ContributeResponseSchema(
         build_id=None,
         build_id_title=BuildIdTitleEnum.url,
@@ -247,7 +259,7 @@ async def get_build_logs_from_url(base64: str) -> ContributeResponseSchema:
 @app.get("/frontend/contribute/container/{base64}")
 async def get_logs_from_container(base64: str) -> ContributeResponseSchema:
     build_url = b64decode(base64).decode("utf-8")
-    provider = ContainerProvider(build_url)
+    provider = ContainerProvider(build_url, http_client=app.state.http_client)
     return ContributeResponseSchema(
         build_id=None,
         build_id_title=BuildIdTitleEnum.container,
@@ -261,7 +273,9 @@ async def get_obs_build_logs(
     project: str, repository: str, architecture: str, package: str
 ) -> ContributeResponseSchema:
     """Return logs and spec file for an OBS build."""
-    provider = OBSProvider(project, repository, architecture, package)
+    provider = OBSProvider(
+        project, repository, architecture, package, http_client=app.state.http_client
+    )
     return ContributeResponseSchema(
         build_id=None,
         build_id_title=BuildIdTitleEnum.obs,
@@ -448,16 +462,14 @@ def frontend_review_random(result_id):
     }
 
 
-async def _check_log_urls(log_urls: list[dict[str, str]]) -> None:
+async def _check_log_urls(
+    log_urls: list[dict[str, str]], http_client: httpx.AsyncClient
+) -> None:
     """Verify all log URLs are reachable using HEAD requests."""
-    async with httpx.AsyncClient() as client:
-        results = await gather(
-            *(
-                client.head(f["url"], follow_redirects=True, timeout=10)
-                for f in log_urls
-            ),
-            return_exceptions=True,
-        )
+    results = await gather(
+        *(http_client.head(f["url"], timeout=10) for f in log_urls),
+        return_exceptions=True,
+    )
     unreachable = []
     for file_info, result in zip(log_urls, results):
         if isinstance(result, BaseException):
@@ -476,6 +488,7 @@ async def _check_log_urls(log_urls: list[dict[str, str]]) -> None:
 
 async def _call_analyze_api(
     log_urls: list[dict[str, str]],
+    http_client: httpx.AsyncClient,
     spec_content: str | None = None,
     provider_name: Optional[str] = None,
 ) -> dict:
@@ -490,7 +503,7 @@ async def _call_analyze_api(
         commentary,
     )
 
-    await _check_log_urls(log_urls)
+    await _check_log_urls(log_urls, http_client=http_client)
 
     data = {
         "files": [{"name": f["name"], "url": f["url"]} for f in log_urls],
@@ -509,17 +522,16 @@ async def _call_analyze_api(
     server_url = f"{SERVER_URL}/analyze"
 
     try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                server_url,
-                headers=headers,
-                json=data,
-                timeout=httpx.Timeout(
-                    LOGDETECTIVE_DEFAULT_TIMEOUT,
-                    connect=LOGDETECTIVE_CONNECT_TIMEOUT,
-                    read=LOGDETECTIVE_READ_TIMEOUT,
-                ),
-            )
+        response = await http_client.post(
+            server_url,
+            headers=headers,
+            json=data,
+            timeout=httpx.Timeout(
+                LOGDETECTIVE_DEFAULT_TIMEOUT,
+                connect=LOGDETECTIVE_CONNECT_TIMEOUT,
+                read=LOGDETECTIVE_READ_TIMEOUT,
+            ),
+        )
     except (httpx.ConnectError, httpx.TimeoutException) as ex:
         raise HTTPException(status_code=408, detail=str(ex)) from ex
 
@@ -535,7 +547,9 @@ async def _call_analyze_api(
     return _process_server_data(response.content)
 
 
-async def _explain_with_provider(provider: Provider, provider_name: str) -> dict:
+async def _explain_with_provider(
+    provider: Provider, provider_name: str, http_client: httpx.AsyncClient
+) -> dict:
     """Fetch log URLs, analyze them, fetch log content, return combined result."""
 
     LOGGER.info("Received request for analysis from: %s", provider_name)
@@ -546,7 +560,14 @@ async def _explain_with_provider(provider: Provider, provider_name: str) -> dict
         spec = await provider.fetch_spec_file()
         spec_content = spec["content"] if spec else None
 
-    analyze_task = create_task(_call_analyze_api(log_urls, spec_content, provider_name))
+    analyze_task = create_task(
+        _call_analyze_api(
+            log_urls,
+            http_client=http_client,
+            spec_content=spec_content,
+            provider_name=provider_name,
+        )
+    )
     content_task = create_task(provider.fetch_logs())
     result, logs = await gather(analyze_task, content_task)
 
@@ -572,8 +593,10 @@ async def frontend_explain_post(request: Request) -> dict:
     file_name = Path(parse.urlparse(url=log_url).path).name
     log_urls = [{"name": file_name, "url": log_url}]
 
-    download_log_task = _download_log_content(log_url)
-    analyze_task = _call_analyze_api(log_urls, provider_name=ProvidersEnum.url)
+    download_log_task = _download_log_content(log_url, client=app.state.http_client)
+    analyze_task = _call_analyze_api(
+        log_urls, provider_name=ProvidersEnum.url, http_client=app.state.http_client
+    )
 
     result, log_data = await gather(analyze_task, download_log_task)
 
@@ -584,34 +607,44 @@ async def frontend_explain_post(request: Request) -> dict:
 
 @app.post("/frontend/explain/copr/{build_id}/{chroot}")
 async def explain_copr(build_id: int, chroot: str) -> dict:
-    provider = CoprProvider(build_id, chroot)
-    return await _explain_with_provider(provider, ProvidersEnum.copr)
+    provider = CoprProvider(build_id, chroot, http_client=app.state.http_client)
+    return await _explain_with_provider(
+        provider, ProvidersEnum.copr, http_client=app.state.http_client
+    )
 
 
 @app.post("/frontend/explain/koji/{build_id}/{chroot}")
 async def explain_koji(build_id: int, chroot: str) -> dict:
-    provider = KojiProvider(build_id, chroot)
-    return await _explain_with_provider(provider, ProvidersEnum.koji)
+    provider = KojiProvider(build_id, chroot, http_client=app.state.http_client)
+    return await _explain_with_provider(
+        provider, ProvidersEnum.koji, http_client=app.state.http_client
+    )
 
 
 @app.post("/frontend/explain/packit/{packit_id}")
 async def explain_packit(packit_id: int) -> dict:
-    provider = PackitProvider(packit_id)
-    return await _explain_with_provider(provider, ProvidersEnum.packit)
+    provider = PackitProvider(packit_id, http_client=app.state.http_client)
+    return await _explain_with_provider(
+        provider, ProvidersEnum.packit, http_client=app.state.http_client
+    )
 
 
 @app.post("/frontend/explain/url/{base64}")
 async def explain_url(base64: str) -> dict:
     url = b64decode(base64).decode("utf-8")
-    provider = URLProvider(url)
-    return await _explain_with_provider(provider, ProvidersEnum.url)
+    provider = URLProvider(url, http_client=app.state.http_client)
+    return await _explain_with_provider(
+        provider, ProvidersEnum.url, http_client=app.state.http_client
+    )
 
 
 @app.post("/frontend/explain/container/{base64}")
 async def explain_container(base64: str) -> dict:
     url = b64decode(base64).decode("utf-8")
-    provider = ContainerProvider(url)
-    return await _explain_with_provider(provider, ProvidersEnum.container)
+    provider = ContainerProvider(url, http_client=app.state.http_client)
+    return await _explain_with_provider(
+        provider, ProvidersEnum.container, http_client=app.state.http_client
+    )
 
 
 @app.post("/frontend/explain/obs/{project}/{repository}/{architecture}/{package}")
@@ -619,8 +652,12 @@ async def explain_obs(
     project: str, repository: str, architecture: str, package: str
 ) -> dict:
     """Forward an OBS build log to the logdetective server for explanation."""
-    provider = OBSProvider(project, repository, architecture, package)
-    return await _explain_with_provider(provider, ProvidersEnum.obs)
+    provider = OBSProvider(
+        project, repository, architecture, package, http_client=app.state.http_client
+    )
+    return await _explain_with_provider(
+        provider, ProvidersEnum.obs, http_client=app.state.http_client
+    )
 
 
 def _process_server_data(data) -> dict:
@@ -663,11 +700,11 @@ def _process_server_data(data) -> dict:
     }
 
 
-async def _download_log_content(url: str) -> str:
+async def _download_log_content(url: str, client: httpx.AsyncClient) -> str:
     """Download content of the log file and returns it."""
 
     try:
-        response = await fetch_text(url, timeout=600)
+        response = await fetch_text(url, client=client, timeout=600)
     except (
         httpx.ConnectError,
         httpx.TimeoutException,

--- a/backend/src/client.py
+++ b/backend/src/client.py
@@ -1,3 +1,7 @@
+"""
+HTTP client utility module
+"""
+
 from httpx import AsyncClient, Timeout, Limits
 
 from src.constants import (

--- a/backend/src/client.py
+++ b/backend/src/client.py
@@ -1,0 +1,19 @@
+from httpx import AsyncClient, Timeout
+
+from src.constants import (
+    LOGDETECTIVE_CONNECT_TIMEOUT,
+    LOGDETECTIVE_DEFAULT_TIMEOUT,
+    LOGDETECTIVE_READ_TIMEOUT,
+)
+
+
+def get_http_client() -> AsyncClient:
+    """Create a new httpx.AsyncClient with application-wide defaults."""
+    return AsyncClient(
+        timeout=Timeout(
+            LOGDETECTIVE_DEFAULT_TIMEOUT,
+            connect=LOGDETECTIVE_CONNECT_TIMEOUT,
+            read=LOGDETECTIVE_READ_TIMEOUT,
+        ),
+        follow_redirects=True,
+    )

--- a/backend/src/client.py
+++ b/backend/src/client.py
@@ -1,9 +1,11 @@
-from httpx import AsyncClient, Timeout
+from httpx import AsyncClient, Timeout, Limits
 
 from src.constants import (
     LOGDETECTIVE_CONNECT_TIMEOUT,
     LOGDETECTIVE_DEFAULT_TIMEOUT,
     LOGDETECTIVE_READ_TIMEOUT,
+    LOGDETECTIVE_MAX_CONNECTION_LIMIT,
+    LOGDETECTIVE_MAX_KEEPALIVE_CONNECTIONS,
 )
 
 
@@ -16,4 +18,8 @@ def get_http_client() -> AsyncClient:
             read=LOGDETECTIVE_READ_TIMEOUT,
         ),
         follow_redirects=True,
+        limits=Limits(
+            max_connections=LOGDETECTIVE_MAX_CONNECTION_LIMIT,
+            max_keepalive_connections=LOGDETECTIVE_MAX_KEEPALIVE_CONNECTIONS,
+        ),
     )

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -28,6 +28,14 @@ SERVER_URL = os.environ.get("SERVER_URL", "http://127.0.0.1:8000")
 # Token used for authorization of analysis requests
 LOG_DETECTIVE_TOKEN = os.environ.get("LOG_DETECTIVE_TOKEN")
 
+# Connection limits for fetcher client
+LOGDETECTIVE_MAX_CONNECTION_LIMIT = int(
+    os.environ.get("LOGDETECTIVE_MAX_CONNECTION_LIMIT", 250)
+)
+LOGDETECTIVE_MAX_KEEPALIVE_CONNECTIONS = int(
+    os.environ.get("LOGDETECTIVE_MAX_KEEPALIVE_CONNECTIONS", 50)
+)
+
 
 class ProvidersEnum(StrEnum):
     packit = "packit"

--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -113,17 +113,23 @@ class RPMProvider(Provider):
 class CoprProvider(RPMProvider):
     copr_url = "https://copr.fedorainfracloud.org"
 
-    def __init__(self, build_id: int, chroot: str) -> None:
+    def __init__(
+        self, build_id: int, chroot: str, http_client: httpx.AsyncClient
+    ) -> None:
         self.build_id = build_id
         self.chroot = chroot
         self.client = copr.v3.Client({"copr_url": self.copr_url})
+        self.http_client = http_client
 
     @handle_errors
     async def fetch_logs(self) -> list[dict[str, str]]:
         baseurl, log_names = self._get_baseurl_and_log_names()
         logs = []
         responses = await asyncio.gather(
-            *[fetch_text("{}/{}".format(baseurl, name)) for name in log_names]
+            *[
+                fetch_text("{}/{}".format(baseurl, name), client=self.http_client)
+                for name in log_names
+            ]
         )
 
         for name, response in zip(log_names, responses):
@@ -179,7 +185,7 @@ class CoprProvider(RPMProvider):
             baseurl = build_chroot.result_url
 
         spec_name = f"{name}.spec"
-        response = await fetch_text(f"{baseurl}/{spec_name}")
+        response = await fetch_text(f"{baseurl}/{spec_name}", client=self.http_client)
         if response.status_code == 404:
             return None
         response.raise_for_status()
@@ -200,12 +206,15 @@ class KojiProvider(RPMProvider):
 
     task_id: int
 
-    def __init__(self, build_or_task_id: int, arch: str) -> None:
+    def __init__(
+        self, build_or_task_id: int, arch: str, http_client: httpx.AsyncClient
+    ) -> None:
         api_url = "{}/kojihub".format(self.koji_url)
         self.client = koji.ClientSession(api_url)
 
         self.arch = arch
         self.build_id = None
+        self.http_client = http_client
         # this block detects what we got: is it build or task?
         # failed builds are useless sadly, we will only work with tasks
         try:
@@ -377,17 +386,16 @@ class KojiProvider(RPMProvider):
             srpm_url = self._get_srpm_url_from_task()
             if not srpm_url:
                 return None
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(srpm_url)
-                if not resp.is_success:
-                    LOGGER.error(
-                        "SRPM %s for task %s not accessible: %s (%s)",
-                        srpm_url,
-                        self.task_id,
-                        resp.status_code,
-                        resp.reason_phrase,
-                    )
-                    return None
+            resp = await self.http_client.get(srpm_url)
+            if not resp.is_success:
+                LOGGER.error(
+                    "SRPM %s for task %s not accessible: %s (%s)",
+                    srpm_url,
+                    self.task_id,
+                    resp.status_code,
+                    resp.reason_phrase,
+                )
+                return None
 
             destination = Path(f"{temp_dir}/{srpm_url.split('/')[-1]}")
             with open(destination, "wb") as srpm_f:
@@ -420,7 +428,7 @@ class KojiProvider(RPMProvider):
             "https://src.fedoraproject.org/rpms/"
             f"{package_name}/raw/{commit_hash}/f/{package_name}.spec"
         )
-        response = await fetch_text(spec_url)
+        response = await fetch_text(spec_url, client=self.http_client)
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -449,10 +457,11 @@ class PackitProvider(RPMProvider):
     packit_api_url = "https://prod.packit.dev/api"
     _provider: Optional[CoprProvider | KojiProvider] = None
 
-    def __init__(self, packit_id: int) -> None:
+    def __init__(self, packit_id: int, http_client: httpx.AsyncClient) -> None:
         self.packit_id = packit_id
         self.copr_url = f"{self.packit_api_url}/copr-builds/{self.packit_id}"
         self.koji_url = f"{self.packit_api_url}/koji-builds/{self.packit_id}"
+        self.http_client = http_client
 
     async def _get_provider(self) -> CoprProvider | KojiProvider:
         if self._provider:
@@ -461,17 +470,20 @@ class PackitProvider(RPMProvider):
         return self._provider
 
     async def _resolve_provider(self) -> CoprProvider | KojiProvider:
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(self.copr_url)
-            if resp.is_success:
-                build = resp.json()
-                return CoprProvider(build["build_id"], build["chroot"])
+        resp = await self.http_client.get(self.copr_url)
+        if resp.is_success:
+            build = resp.json()
+            return CoprProvider(
+                build_id=build["build_id"],
+                chroot=build["chroot"],
+                http_client=self.http_client,
+            )
 
-            resp = await client.get(self.koji_url)
-            if not resp.is_success:
-                raise FetchError(
-                    f"Couldn't find any build logs for Packit ID #{self.packit_id}."
-                )
+        resp = await self.http_client.get(self.koji_url)
+        if not resp.is_success:
+            raise FetchError(
+                f"Couldn't find any build logs for Packit ID #{self.packit_id}."
+            )
 
         build = resp.json()
         task_id = build["task_id"]
@@ -481,7 +493,9 @@ class PackitProvider(RPMProvider):
         if arch is None:
             raise FetchError(f"No arch was found for koji task #{task_id}")
 
-        return KojiProvider(task_id, arch)
+        return KojiProvider(
+            build_or_task_id=task_id, arch=arch, http_client=self.http_client
+        )
 
     @handle_errors
     async def fetch_logs(self) -> list[dict[str, str]]:
@@ -508,14 +522,15 @@ class PackitProvider(RPMProvider):
 
 
 class URLProvider(RPMProvider):
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, http_client: httpx.AsyncClient) -> None:
         self.url = url
+        self.http_client = http_client
 
     @handle_errors
     async def fetch_logs(self) -> list[dict[str, str]]:
         # TODO Can we recognize a directory listing and show _all_ logs?
         #  also this will allow us to fetch spec files
-        response = await fetch_text(self.url)
+        response = await fetch_text(self.url, client=self.http_client)
         response.raise_for_status()
         if "text/plain" not in response.headers["Content-Type"]:
             raise FetchError(
@@ -544,13 +559,14 @@ class ContainerProvider(Provider):
     Fetching container logs only from URL for now
     """
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, http_client: httpx.AsyncClient) -> None:
         self.url = url
+        self.http_client = http_client
 
     @handle_errors
     async def fetch_logs(self) -> list[dict[str, str]]:
         # TODO: c&p from url provider for now, integrate with containers better later on
-        response = await fetch_text(self.url)
+        response = await fetch_text(self.url, client=self.http_client)
         response.raise_for_status()
         if "text/plain" not in response.headers["Content-Type"]:
             raise FetchError(
@@ -582,12 +598,18 @@ class OBSProvider(RPMProvider):
     )
 
     def __init__(
-        self, project: str, repository: str, architecture: str, package: str
+        self,
+        project: str,
+        repository: str,
+        architecture: str,
+        package: str,
+        http_client: httpx.AsyncClient,
     ) -> None:
         self.project = project
         self.repository = repository
         self.architecture = architecture
         self.package = package
+        self.http_client = http_client
 
     @cached_property
     def log_url(self) -> str:
@@ -601,7 +623,7 @@ class OBSProvider(RPMProvider):
 
     @handle_errors
     async def fetch_logs(self) -> list[dict[str, str]]:
-        response = await fetch_text(self.log_url)
+        response = await fetch_text(self.log_url, client=self.http_client)
         response.raise_for_status()
         content_type = response.headers.get("Content-Type", "")
         if "text/plain" not in content_type:
@@ -620,7 +642,7 @@ class OBSProvider(RPMProvider):
         url = self.obs_spec_url.format(
             project=self.project, package=self.package, filename=spec_name
         )
-        response = await fetch_text(url)
+        response = await fetch_text(url, client=self.http_client)
         if response.status_code == 404:
             return None
         response.raise_for_status()

--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -132,7 +132,7 @@ def read_text_file(path: Path | str) -> str:
         return fp.read()
 
 
-async def fetch_text(url: str, **kwargs) -> httpx.Response:
+async def fetch_text(url: str, client: httpx.AsyncClient, **kwargs) -> httpx.Response:
     """
     Fetch text content from URL with consistent UTF-8 encoding.
 
@@ -143,9 +143,9 @@ async def fetch_text(url: str, **kwargs) -> httpx.Response:
     Returns:
         httpx.Response with encoding set to UTF-8
     """
-    async with httpx.AsyncClient() as client:
-        response = await client.get(url, **kwargs)
-        response.encoding = "utf-8"
+
+    response = await client.get(url, **kwargs)
+    response.encoding = "utf-8"
     return response
 
 

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -13,6 +13,14 @@ from starlette.exceptions import HTTPException
 
 from src.api import app
 
+
+@pytest.fixture(autouse=True)
+def _provide_app_http_client():
+    """Ensure app.state.http_client exists for tests that bypass lifespan."""
+    app.state.http_client = MagicMock()
+    yield
+
+
 FAKE_LOG_CONTENT = "mock build log content"
 FAKE_SPEC = {"name": "test.spec", "content": "spec content"}
 
@@ -172,14 +180,19 @@ class TestContributeEndpoints:
         )
         assert len(data["logs"]) == 1
         assert data["spec_file"] is None
-        mock_cls.assert_called_once_with("openSUSE:Factory", "standard", "x86_64", "ed")
+        mock_cls.assert_called_once_with(
+            "openSUSE:Factory",
+            "standard",
+            "x86_64",
+            "ed",
+            http_client=app.state.http_client,
+        )
 
 
 class TestExplainEndpoint:
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api._download_log_content", new_callable=AsyncMock)
-    @patch("src.api.httpx.AsyncClient")
-    async def test_explain_success(self, mock_client_cls, mock_download, _mock_check):
+    async def test_explain_success(self, mock_download, _mock_check):
         mock_download.return_value = FAKE_LOG_CONTENT
 
         mock_response = MagicMock()
@@ -190,9 +203,7 @@ class TestExplainEndpoint:
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
+        app.state.http_client = mock_client
 
         transport = httpx.ASGITransport(app=app)
         async with RealAsyncClient(
@@ -213,17 +224,12 @@ class TestExplainEndpoint:
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api._download_log_content", new_callable=AsyncMock)
-    @patch("src.api.httpx.AsyncClient")
-    async def test_explain_server_timeout(
-        self, mock_client_cls, mock_download, _mock_check
-    ):
+    async def test_explain_server_timeout(self, mock_download, _mock_check):
         mock_download.return_value = FAKE_LOG_CONTENT
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
+        app.state.http_client = mock_client
 
         transport = httpx.ASGITransport(app=app)
         async with RealAsyncClient(
@@ -238,19 +244,14 @@ class TestExplainEndpoint:
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api._download_log_content", new_callable=AsyncMock)
-    @patch("src.api.httpx.AsyncClient")
-    async def test_explain_server_connect_error(
-        self, mock_client_cls, mock_download, _mock_check
-    ):
+    async def test_explain_server_connect_error(self, mock_download, _mock_check):
         mock_download.return_value = FAKE_LOG_CONTENT
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(
             side_effect=httpx.ConnectError("connection refused")
         )
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
+        app.state.http_client = mock_client
 
         transport = httpx.ASGITransport(app=app)
         async with RealAsyncClient(
@@ -265,10 +266,7 @@ class TestExplainEndpoint:
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api._download_log_content", new_callable=AsyncMock)
-    @patch("src.api.httpx.AsyncClient")
-    async def test_explain_server_500(
-        self, mock_client_cls, mock_download, _mock_check
-    ):
+    async def test_explain_server_500(self, mock_download, _mock_check):
         mock_download.return_value = FAKE_LOG_CONTENT
 
         mock_response = MagicMock()
@@ -286,9 +284,7 @@ class TestExplainEndpoint:
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
+        app.state.http_client = mock_client
 
         transport = httpx.ASGITransport(app=app)
         async with RealAsyncClient(
@@ -488,12 +484,17 @@ class TestExplainProviderEndpoints:
         data = resp.json()
         assert "explanation" in data
         assert "logs" in data
-        mock_cls.assert_called_once_with("openSUSE:Factory", "standard", "x86_64", "ed")
+        mock_cls.assert_called_once_with(
+            "openSUSE:Factory",
+            "standard",
+            "x86_64",
+            "ed",
+            http_client=app.state.http_client,
+        )
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
-    @patch("src.api.httpx.AsyncClient")
     @patch("src.api.CoprProvider")
-    async def test_explain_provider_timeout(self, mock_cls, mock_http_cls, _mock_check):
+    async def test_explain_provider_timeout(self, mock_cls, _mock_check):
         mock_provider = mock_cls.return_value
         mock_provider.fetch_log_urls = AsyncMock(
             return_value=[{"name": "build.log", "url": "https://example.com/build.log"}]
@@ -505,9 +506,7 @@ class TestExplainProviderEndpoints:
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_http_cls.return_value = mock_client
+        app.state.http_client = mock_client
 
         transport = httpx.ASGITransport(app=app)
         async with RealAsyncClient(
@@ -518,11 +517,8 @@ class TestExplainProviderEndpoints:
         assert resp.status_code == 408
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
-    @patch("src.api.httpx.AsyncClient")
     @patch("src.api.CoprProvider")
-    async def test_explain_provider_server_error(
-        self, mock_cls, mock_http_cls, _mock_check
-    ):
+    async def test_explain_provider_server_error(self, mock_cls, _mock_check):
         mock_provider = mock_cls.return_value
         mock_provider.fetch_log_urls = AsyncMock(
             return_value=[{"name": "build.log", "url": "https://example.com/build.log"}]
@@ -547,9 +543,7 @@ class TestExplainProviderEndpoints:
 
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_http_cls.return_value = mock_client
+        app.state.http_client = mock_client
 
         transport = httpx.ASGITransport(app=app)
         async with RealAsyncClient(
@@ -563,8 +557,7 @@ class TestExplainProviderEndpoints:
 class TestCheckLogUrls:
     """Tests for _check_log_urls."""
 
-    @patch("src.api.httpx.AsyncClient")
-    async def test_all_reachable(self, mock_client_cls):
+    async def test_all_reachable(self):
         from src.api import _check_log_urls
 
         mock_response = MagicMock()
@@ -572,19 +565,16 @@ class TestCheckLogUrls:
 
         mock_client = AsyncMock()
         mock_client.head = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
 
         await _check_log_urls(
             [
                 {"name": "build.log", "url": "https://example.com/build.log"},
                 {"name": "root.log", "url": "https://example.com/root.log"},
-            ]
+            ],
+            http_client=mock_client,
         )
 
-    @patch("src.api.httpx.AsyncClient")
-    async def test_unreachable_url_returns_404(self, mock_client_cls):
+    async def test_unreachable_url_returns_404(self):
         from src.api import _check_log_urls
 
         mock_response = MagicMock()
@@ -592,36 +582,31 @@ class TestCheckLogUrls:
 
         mock_client = AsyncMock()
         mock_client.head = AsyncMock(return_value=mock_response)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
 
         with pytest.raises(HTTPException) as exc_info:
             await _check_log_urls(
                 [
                     {"name": "build.log", "url": "https://example.com/missing.log"},
-                ]
+                ],
+                http_client=mock_client,
             )
         assert exc_info.value.status_code == 422
         assert "missing.log" in exc_info.value.detail
 
-    @patch("src.api.httpx.AsyncClient")
-    async def test_unreachable_url_connection_error(self, mock_client_cls):
+    async def test_unreachable_url_connection_error(self):
         from src.api import _check_log_urls
 
         mock_client = AsyncMock()
         mock_client.head = AsyncMock(
             side_effect=httpx.ConnectError("connection refused")
         )
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client_cls.return_value = mock_client
 
         with pytest.raises(HTTPException) as exc_info:
             await _check_log_urls(
                 [
                     {"name": "build.log", "url": "https://example.com/build.log"},
-                ]
+                ],
+                http_client=mock_client,
             )
         assert exc_info.value.status_code == 422
         assert "connection refused" in exc_info.value.detail

--- a/backend/tests/unit/test_fetcher.py
+++ b/backend/tests/unit/test_fetcher.py
@@ -63,7 +63,7 @@ class TestCoprProvider:
 
         logs = copr_srpm_logs if chroot == "srpm-builds" else copr_chroot_logs
 
-        provider = CoprProvider(123, chroot)
+        provider = CoprProvider(123, chroot, http_client=MagicMock())
         if not baseurl:
             with pytest.raises(FetchError):
                 await provider.fetch_logs()
@@ -111,12 +111,16 @@ class TestCoprProvider:
         url_map = {f"{baseurl}/{spec_name}": (fake_spec_file, 200)}
 
         with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
-            result = await CoprProvider(123, chroot).fetch_spec_file()
+            result = await CoprProvider(
+                123, chroot, http_client=MagicMock()
+            ).fetch_spec_file()
         assert {"name": spec_name, "content": fake_spec_file} == result
 
         url_map_404 = {f"{baseurl}/{spec_name}": ("", 404)}
         with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map_404)):
-            result = await CoprProvider(123, chroot).fetch_spec_file()
+            result = await CoprProvider(
+                123, chroot, http_client=MagicMock()
+            ).fetch_spec_file()
         assert result is None
 
     @patch.object(BuildProxy, "get")
@@ -138,7 +142,7 @@ class TestCoprProvider:
             for name in ["builder-live.log.gz", "backend.log.gz", "build.log.gz"]
         }
 
-        provider = CoprProvider(123, chroot)
+        provider = CoprProvider(123, chroot, http_client=MagicMock())
         with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
             logs = await provider.fetch_logs()
 
@@ -168,7 +172,7 @@ class TestCoprProvider:
         mock_build_proxy.return_value = MagicMock(
             ownername="ownername", project_dirname="dirname", id=123
         )
-        provider = CoprProvider(123, chroot)
+        provider = CoprProvider(123, chroot, http_client=MagicMock())
         result = await provider.fetch_log_urls()
 
         for entry in result:
@@ -191,7 +195,7 @@ class TestCoprProvider:
         mock_build_proxy.return_value = MagicMock(
             ownername="ownername", project_dirname="dirname", id=123
         )
-        provider = CoprProvider(123, "fedora-39_x86_64")
+        provider = CoprProvider(123, "fedora-39_x86_64", http_client=MagicMock())
         with pytest.raises(FetchError):
             await provider.fetch_log_urls()
 
@@ -199,19 +203,24 @@ class TestCoprProvider:
 class TestURLProvider:
     async def test_fetch_url_logs(self):
         url = "https://www.fake.lol"
-        provider = URLProvider(url)
+        provider = URLProvider(url, http_client=MagicMock())
         url_map = {url: ("text", 200)}
         with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
             result = await provider.fetch_logs()
         assert result == [{"name": "build.log", "content": "text"}]
 
     async def test_fetch_url_spec(self):
-        assert await URLProvider("https://www.fake.lol").fetch_spec_file() is None
+        assert (
+            await URLProvider(
+                "https://www.fake.lol", http_client=MagicMock()
+            ).fetch_spec_file()
+            is None
+        )
 
     async def test_fetch_url_logs_with_utf8(self):
         url = "https://www.fake.lol/log.txt"
         czech_content = "Chyba: balíček nebyl nalezen\nŘešení: přidejte repozitář"
-        provider = URLProvider(url)
+        provider = URLProvider(url, http_client=MagicMock())
         url_map = {url: (czech_content, 200)}
         with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
             logs = await provider.fetch_logs()
@@ -219,7 +228,7 @@ class TestURLProvider:
 
     async def test_fetch_log_urls(self):
         url = "https://www.fake.lol/build.log"
-        provider = URLProvider(url)
+        provider = URLProvider(url, http_client=MagicMock())
         result = await provider.fetch_log_urls()
         assert result == [{"name": "build.log", "url": url}]
 
@@ -241,7 +250,11 @@ class TestOBSProvider:
 
     def _provider(self):
         return OBSProvider(
-            self.project, self.repository, self.architecture, self.package
+            self.project,
+            self.repository,
+            self.architecture,
+            self.package,
+            http_client=MagicMock(),
         )
 
     async def test_fetch_logs(self):
@@ -298,7 +311,7 @@ class TestKojiProviderLogs:
             downloadTaskOutput=MagicMock(return_value="LOG_CONTENT"),
         )
         mock_task_info.return_value = request.getfixturevalue(f_task_dict)
-        koji_provider = KojiProvider(123, "noarch")
+        koji_provider = KojiProvider(123, "noarch", http_client=MagicMock())
         logs = await koji_provider.fetch_logs()
         assert len(logs) == 5
         for log in logs:
@@ -315,7 +328,7 @@ class TestKojiProviderLogs:
             downloadTaskOutput=MagicMock(return_value=czech_log.encode("utf-8")),
         )
         mock_task_info.return_value = srpm_task_dict
-        koji_provider = KojiProvider(123, "noarch")
+        koji_provider = KojiProvider(123, "noarch", http_client=MagicMock())
         logs = await koji_provider.fetch_logs()
         for log in logs:
             assert log["content"] == czech_log
@@ -367,7 +380,9 @@ class TestKojiProviderLogs:
         url_map = {spec_url: (fake_spec_file, 200)}
         expected = {"name": "copr-frontend.spec", "content": fake_spec_file}
         with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
-            result = await KojiProvider(123, "noarch").fetch_spec_file()
+            result = await KojiProvider(
+                123, "noarch", http_client=MagicMock()
+            ).fetch_spec_file()
         assert expected == result
 
     @patch.object(KojiProvider, "_fetch_spec_file_from_task_id", new_callable=AsyncMock)
@@ -386,7 +401,9 @@ class TestKojiProviderLogs:
         mock_get_task_request_url.return_value = None
         expected = {"name": "copr-fronend.spec", "content": fake_spec_file}
         mock_fetch_spec_file_from_task_id.return_value = expected
-        result = await KojiProvider(123, "noarch").fetch_spec_file()
+        result = await KojiProvider(
+            123, "noarch", http_client=MagicMock()
+        ).fetch_spec_file()
         assert expected == result
 
     @patch.object(KojiProvider, "_fetch_spec_file_from_task_id", new_callable=AsyncMock)
@@ -404,7 +421,9 @@ class TestKojiProviderLogs:
         )
         mock_get_task_request_url.return_value = None
         mock_fetch_spec_file_from_task_id.return_value = None
-        koji_result = await KojiProvider(123, "noarch").fetch_spec_file()
+        koji_result = await KojiProvider(
+            123, "noarch", http_client=MagicMock()
+        ).fetch_spec_file()
         assert koji_result is None
 
     @patch.object(koji, "ClientSession")
@@ -418,7 +437,7 @@ class TestKojiProviderLogs:
                 return_value={str(root_task_id): copr_task_descendants}
             ),
         )
-        KojiProvider(123, "noarch")
+        KojiProvider(123, "noarch", http_client=MagicMock())
 
     @patch.object(koji, "ClientSession")
     @patch.object(KojiProvider, "task_info", new_callable=PropertyMock)
@@ -432,7 +451,7 @@ class TestKojiProviderLogs:
             listTaskOutput=MagicMock(return_value=available_files),
         )
         mock_task_info.return_value = srpm_task_dict
-        provider = KojiProvider(task_id, "noarch")
+        provider = KojiProvider(task_id, "noarch", http_client=MagicMock())
         result = await provider.fetch_log_urls()
 
         expected_relpath = f"tasks/{task_id % 10000}/{task_id}"
@@ -457,14 +476,14 @@ class TestKojiProviderLogs:
             listTaskOutput=MagicMock(return_value=["state.log"]),
         )
         mock_task_info.return_value = srpm_task_dict
-        provider = KojiProvider(123, "noarch")
+        provider = KojiProvider(123, "noarch", http_client=MagicMock())
         with pytest.raises(FetchError):
             await provider.fetch_log_urls()
 
 
 class TestPackitProvider:
     packit_id = 123
-    packit_provider = PackitProvider(packit_id)
+    packit_provider = PackitProvider(packit_id, http_client=MagicMock())
 
     @patch.object(BuildProxy, "get")
     @patch.object(BuildChrootProxy, "get")
@@ -494,13 +513,11 @@ class TestPackitProvider:
 
         transport = httpx.MockTransport(_transport_handler)
 
-        with patch(
-            "src.fetcher.httpx.AsyncClient",
-            return_value=httpx.AsyncClient(transport=transport),
-        ):
-            with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
-                provider = PackitProvider(self.packit_id)
-                logs = await provider.fetch_logs()
+        with patch("src.fetcher.fetch_text", side_effect=_mock_fetch_text(url_map)):
+            provider = PackitProvider(
+                self.packit_id, http_client=httpx.AsyncClient(transport=transport)
+            )
+            logs = await provider.fetch_logs()
 
         for log in logs:
             assert log["content"] == czech_log
@@ -517,13 +534,11 @@ class TestPackitProvider:
             return httpx.Response(404)
 
         transport = httpx.MockTransport(_handler)
-        provider = PackitProvider(self.packit_id)
+        provider = PackitProvider(
+            self.packit_id, http_client=httpx.AsyncClient(transport=transport)
+        )
 
-        with patch(
-            "src.fetcher.httpx.AsyncClient",
-            return_value=httpx.AsyncClient(transport=transport),
-        ):
-            correct_provider = await provider._resolve_provider()
+        correct_provider = await provider._resolve_provider()
 
         assert isinstance(correct_provider, CoprProvider)
         assert correct_provider.build_id == build_id
@@ -547,13 +562,11 @@ class TestPackitProvider:
             return httpx.Response(404)
 
         transport = httpx.MockTransport(_handler)
-        provider = PackitProvider(self.packit_id)
+        provider = PackitProvider(
+            self.packit_id, http_client=httpx.AsyncClient(transport=transport)
+        )
 
-        with patch(
-            "src.fetcher.httpx.AsyncClient",
-            return_value=httpx.AsyncClient(transport=transport),
-        ):
-            correct_provider = await provider._resolve_provider()
+        correct_provider = await provider._resolve_provider()
 
         assert isinstance(correct_provider, KojiProvider)
 
@@ -562,18 +575,16 @@ class TestPackitProvider:
             return httpx.Response(404)
 
         transport = httpx.MockTransport(_handler)
-        provider = PackitProvider(self.packit_id)
+        provider = PackitProvider(
+            self.packit_id, http_client=httpx.AsyncClient(transport=transport)
+        )
 
-        with patch(
-            "src.fetcher.httpx.AsyncClient",
-            return_value=httpx.AsyncClient(transport=transport),
-        ):
-            with pytest.raises(FetchError):
-                await provider._resolve_provider()
+        with pytest.raises(FetchError):
+            await provider._resolve_provider()
 
     async def test_get_url_copr(self):
         mock_copr = MagicMock(spec=CoprProvider)
-        provider = PackitProvider(self.packit_id)
+        provider = PackitProvider(self.packit_id, http_client=MagicMock())
         with patch.object(
             provider, "_get_provider", new=AsyncMock(return_value=mock_copr)
         ):
@@ -584,7 +595,7 @@ class TestPackitProvider:
 
     async def test_get_url_koji(self):
         mock_koji = MagicMock(spec=KojiProvider)
-        provider = PackitProvider(self.packit_id)
+        provider = PackitProvider(self.packit_id, http_client=MagicMock())
         with patch.object(
             provider, "_get_provider", new=AsyncMock(return_value=mock_koji)
         ):
@@ -597,7 +608,7 @@ class TestPackitProvider:
         fake_urls = [{"name": "build.log", "url": "https://example.com/build.log"}]
         mock_inner = AsyncMock()
         mock_inner.fetch_log_urls = AsyncMock(return_value=fake_urls)
-        provider = PackitProvider(self.packit_id)
+        provider = PackitProvider(self.packit_id, http_client=MagicMock())
         with patch.object(
             provider, "_get_provider", new=AsyncMock(return_value=mock_inner)
         ):
@@ -618,7 +629,7 @@ class TestContainerProvider:
                 request=httpx.Request("GET", u),
             )
 
-        provider = ContainerProvider(url)
+        provider = ContainerProvider(url, http_client=MagicMock())
         with patch("src.fetcher.fetch_text", side_effect=_fake_fetch_text):
             result = await provider.fetch_logs()
         assert result == [{"name": "Container log", "content": content}]
@@ -634,7 +645,7 @@ class TestContainerProvider:
                 request=httpx.Request("GET", u),
             )
 
-        provider = ContainerProvider(url)
+        provider = ContainerProvider(url, http_client=MagicMock())
         with patch("src.fetcher.fetch_text", side_effect=_fake_fetch_text):
             with pytest.raises(FetchError):
                 await provider.fetch_logs()
@@ -650,7 +661,7 @@ class TestContainerProvider:
                 request=httpx.Request("GET", u),
             )
 
-        provider = ContainerProvider(url)
+        provider = ContainerProvider(url, http_client=MagicMock())
         with patch("src.fetcher.fetch_text", side_effect=_fake_fetch_text):
             from fastapi import HTTPException
 
@@ -660,6 +671,6 @@ class TestContainerProvider:
 
     async def test_fetch_log_urls(self):
         url = "https://example.com/container.log"
-        provider = ContainerProvider(url)
+        provider = ContainerProvider(url, http_client=MagicMock())
         result = await provider.fetch_log_urls()
         assert result == [{"name": "Container log", "url": url}]

--- a/backend/tests/unit/test_spells.py
+++ b/backend/tests/unit/test_spells.py
@@ -49,11 +49,8 @@ class TestFetchText:
             )
 
         transport = httpx.MockTransport(_handler)
-        with patch(
-            "src.spells.httpx.AsyncClient",
-            return_value=httpx.AsyncClient(transport=transport),
-        ):
-            response = await fetch_text(url)
+        client = httpx.AsyncClient(transport=transport)
+        response = await fetch_text(url, client=client)
 
         assert response.encoding == "utf-8"
         assert response.text == czech_text


### PR DESCRIPTION
Instead of instantiating new client for every call, we will have a single central client for all fetchers in the app. This way we can simplify the maintenance and control over it. Limits on connections are newly parametrized, set to about 2.5 of the default value.

Ruff formatting of the affected files is part of the PR.