### PR TITLE
Better resolution of gateway timeout errors

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -532,8 +532,16 @@ async def _call_analyze_api(
                 read=LOGDETECTIVE_READ_TIMEOUT,
             ),
         )
-    except (httpx.ConnectError, httpx.TimeoutException) as ex:
-        raise HTTPException(status_code=408, detail=str(ex)) from ex
+    except httpx.TimeoutException as ex:
+        raise HTTPException(
+            status_code=HTTPStatus.GATEWAY_TIMEOUT,
+            detail=f"Request to analysis server timed out: {ex}",
+        ) from ex
+    except httpx.RequestError as ex:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_GATEWAY,
+            detail=f"Could not connect to analysis server: {ex}",
+        ) from ex
 
     try:
         LOGGER.debug(
@@ -705,12 +713,16 @@ async def _download_log_content(url: str, client: httpx.AsyncClient) -> str:
 
     try:
         response = await fetch_text(url, client=client, timeout=600)
-    except (
-        httpx.ConnectError,
-        httpx.TimeoutException,
-        httpx.RequestError,
-    ) as ex:
-        raise HTTPException(status_code=408, detail=str(ex)) from ex
+    except httpx.TimeoutException as ex:
+        raise HTTPException(
+            status_code=HTTPStatus.GATEWAY_TIMEOUT,
+            detail=f"Request to download log file timed out: {ex}",
+        ) from ex
+    except httpx.RequestError as ex:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_GATEWAY,
+            detail=f"Could not connect to log file URL: {ex}",
+        ) from ex
     try:
         response.raise_for_status()
     except httpx.HTTPError as ex:

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -725,7 +725,7 @@ async def _download_log_content(url: str, client: httpx.AsyncClient) -> str:
     """Download content of the log file and returns it."""
 
     try:
-        response = await fetch_text(url, client=client, timeout=600)
+        response = await fetch_text(url, client=client)
     except httpx.TimeoutException as ex:
         raise HTTPException(
             status_code=HTTPStatus.GATEWAY_TIMEOUT,

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -486,6 +486,17 @@ async def _check_log_urls(
         raise HTTPException(status_code=422, detail=f"Unreachable log files: {detail}")
 
 
+def _extract_error_detail_from_response(response: httpx.Response) -> str:
+    """Extract error detail from a httpx.Response object.
+    Note: logs at ERROR level as a side effect."""
+    try:
+        server_detail = response.json().get("detail", response.text)
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        server_detail = response.text
+    LOGGER.error("Analysis server error %s: %s", response.status_code, server_detail)
+    return f"{response.status_code} {response.reason_phrase}\n{response.url}\n{server_detail}"
+
+
 async def _call_analyze_api(
     log_urls: list[dict[str, str]],
     http_client: httpx.AsyncClient,
@@ -549,8 +560,10 @@ async def _call_analyze_api(
         )
         response.raise_for_status()
     except httpx.HTTPError as ex:
-        detail = f"{response.status_code} {response.reason_phrase}\n{response.url}"
-        raise HTTPException(status_code=response.status_code, detail=detail) from ex
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=_extract_error_detail_from_response(response),
+        ) from ex
 
     return _process_server_data(response.content)
 
@@ -726,8 +739,10 @@ async def _download_log_content(url: str, client: httpx.AsyncClient) -> str:
     try:
         response.raise_for_status()
     except httpx.HTTPError as ex:
-        detail = f"{response.status_code} {response.reason_phrase}\n{response.url}"
-        raise HTTPException(status_code=response.status_code, detail=detail) from ex
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=_extract_error_detail_from_response(response),
+        ) from ex
 
     return response.text
 

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -21,6 +21,11 @@ LOGDETECTIVE_DEFAULT_TIMEOUT = float(
     os.environ.get("LOGDETECTIVE_DEFAULT_TIMEOUT", 3.07)
 )
 
+# How long we wait for remote file servers to respond before giving up on fetching a file
+# Applies only to specfiles since logs are only submitted as URLS and
+# their download is handled as a part of the logdetective server's request
+FETCH_TIMEOUT = float(os.environ.get("FETCH_TIMEOUT", 600))
+
 COPR_RESULT_TEMPLATE = (
     "https://download.copr.fedorainfracloud.org" + "/results/{0}/{1}/srpm-builds/{2:08}"
 )

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -9,7 +9,9 @@ OBS_BUILD_URL = "https://build.opensuse.org/package/show/{0}/{1}"
 FEEDBACK_DIR = os.environ.get("FEEDBACK_DIR", "/persistent/results")
 REVIEWS_DIR = os.environ.get("REVIEWS_DIR", "/persistent/reviews")
 
-LOGDETECTIVE_READ_TIMEOUT = float(os.environ.get("LOGDETECTIVE_READ_TIMEOUT", 1800))
+# Gunicorn worker timeout (files/gunicorn.conf.py) must be > this value.
+# Note: > 90 % analysis requests finish within 30 seconds as of June 2026.
+LOGDETECTIVE_READ_TIMEOUT = float(os.environ.get("LOGDETECTIVE_READ_TIMEOUT", 600))
 # Set to slightly more than retransmission window of 3s from RFC2988
 # https://datatracker.ietf.org/doc/html/rfc2988
 LOGDETECTIVE_CONNECT_TIMEOUT = float(

--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -14,7 +14,11 @@ import koji
 import httpx
 from fastapi import HTTPException
 
-from src.constants import COPR_RESULT_TEMPLATE, LOGGER_NAME
+from src.constants import (
+    COPR_RESULT_TEMPLATE,
+    LOGGER_NAME,
+    FETCH_TIMEOUT,
+)
 from src.exceptions import FetchError
 from src.spells import (
     get_temporary_dir,
@@ -396,7 +400,7 @@ class KojiProvider(RPMProvider):
             srpm_url = self._get_srpm_url_from_task()
             if not srpm_url:
                 return None
-            resp = await self.http_client.get(srpm_url)
+            resp = await self.http_client.get(srpm_url, timeout=FETCH_TIMEOUT)
             if not resp.is_success:
                 LOGGER.error(
                     "SRPM %s for task %s not accessible: %s (%s)",

--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -37,6 +37,16 @@ def handle_errors(func):
     async def inner(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
+        except httpx.TimeoutException as ex:
+            raise HTTPException(
+                status_code=HTTPStatus.GATEWAY_TIMEOUT,
+                detail=f"Request to the server timed out: {ex}",
+            ) from ex
+        except httpx.RequestError as ex:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_GATEWAY,
+                detail=f"Could not connect to the server: {ex}",
+            ) from ex
         except HTTPException:
             raise
         except (copr.v3.exceptions.CoprNoResultException, koji.GenericError) as ex:

--- a/backend/src/fetcher.py
+++ b/backend/src/fetcher.py
@@ -483,8 +483,11 @@ class PackitProvider(RPMProvider):
         self._provider = await self._resolve_provider()
         return self._provider
 
+    @handle_errors
     async def _resolve_provider(self) -> CoprProvider | KojiProvider:
-        resp = await self.http_client.get(self.copr_url)
+        # This GET does not download any files, it just gets build metadata
+        # 20min timeout seemed like too much, but the default 5s seemed too little
+        resp = await self.http_client.get(self.copr_url, timeout=30)
         if resp.is_success:
             build = resp.json()
             return CoprProvider(
@@ -493,7 +496,8 @@ class PackitProvider(RPMProvider):
                 http_client=self.http_client,
             )
 
-        resp = await self.http_client.get(self.koji_url)
+        # Same reasoning for the timeout, as above
+        resp = await self.http_client.get(self.koji_url, timeout=30)
         if not resp.is_success:
             raise FetchError(
                 f"Couldn't find any build logs for Packit ID #{self.packit_id}."

--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -30,7 +30,11 @@ from src.log_cleaning import (
     html_careful_unescape,
     log_schema_redaction,
 )
-from src.constants import DEFAULT_ROBOTS, STATIC_SOURCE_DIR
+from src.constants import (
+    DEFAULT_ROBOTS,
+    STATIC_SOURCE_DIR,
+    FETCH_TIMEOUT,
+)
 
 
 @contextmanager
@@ -132,19 +136,21 @@ def read_text_file(path: Path | str) -> str:
         return fp.read()
 
 
-async def fetch_text(url: str, client: httpx.AsyncClient, **kwargs) -> httpx.Response:
+async def fetch_text(
+    url: str, client: httpx.AsyncClient, timeout: float = FETCH_TIMEOUT, **kwargs
+) -> httpx.Response:
     """
     Fetch text content from URL with consistent UTF-8 encoding.
 
     Args:
         url: The URL to fetch
+        timeout (default=FETCH_TIMEOUT): Request timeout in seconds to override httpx 5sec default
         **kwargs: Additional arguments passed to AsyncClient.get()
 
     Returns:
         httpx.Response with encoding set to UTF-8
     """
-
-    response = await client.get(url, **kwargs)
+    response = await client.get(url, timeout=timeout, **kwargs)
     response.encoding = "utf-8"
     return response
 

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -240,7 +240,7 @@ class TestExplainEndpoint:
                 json={"prompt": "https://example.com/build.log"},
             )
 
-        assert resp.status_code == 408
+        assert resp.status_code == 504
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api._download_log_content", new_callable=AsyncMock)
@@ -262,7 +262,7 @@ class TestExplainEndpoint:
                 json={"prompt": "https://example.com/build.log"},
             )
 
-        assert resp.status_code == 408
+        assert resp.status_code == 502
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api._download_log_content", new_callable=AsyncMock)
@@ -514,7 +514,7 @@ class TestExplainProviderEndpoints:
         ) as client:
             resp = await client.post("/frontend/explain/copr/123/fedora-39-x86_64")
 
-        assert resp.status_code == 408
+        assert resp.status_code == 504
 
     @patch("src.api._check_log_urls", new_callable=AsyncMock)
     @patch("src.api.CoprProvider")

--- a/files/env
+++ b/files/env
@@ -1,7 +1,7 @@
 STORAGE_DIR=/persistent
 FEEDBACK_DIR=/persistent/results
 REVIEWS_DIR=/persistent/reviews
-LOGDETECTIVE_READ_TIMEOUT=1800
+LOGDETECTIVE_READ_TIMEOUT=600
 # Set to slightly more than retransmission window of 3s from RFC2988
 # https://datatracker.ietf.org/doc/html/rfc2988
 LOGDETECTIVE_CONNECT_TIMEOUT=3.07

--- a/files/gunicorn.conf.py
+++ b/files/gunicorn.conf.py
@@ -8,5 +8,7 @@ max_requests = 100
 max_requests_jitter = 10
 threads = multiprocessing.cpu_count() * 2
 bind = "0.0.0.0:8080"
-timeout = 1800
+# Must be larger than LOGDETECTIVE_READ_TIMEOUT (backend/src/constants.py).
+# to allow leeway for parsing, error handling, etc.
+timeout = 630
 accesslog = "-"


### PR DESCRIPTION
- synchronized worker timeouts between website and service (600s)
    - Maybe we should put some extra leeway for the website worker to account for parsing, url checks etc?
- added explicit timeouts to specfile and log fetching to override httpx default 5s
- changed 408 timeout to 504 to avoid browser retriggering and unparseable error response
- improved error handling by catching most of httpx errors and raising 502 (except for timeouts - 504)