### PR TITLE
Improve HTTP error display

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -142,10 +142,7 @@ def _custom_http_exception_handler(
 
     return JSONResponse(
         status_code=status_code,
-        content={
-            "error": f"Server error: {status_code}",
-            "description": description,
-        },
+        content={"description": description},
     )
 
 

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -135,6 +135,16 @@ def _custom_http_exception_handler(
 
     if isinstance(exc, HTTPException):
         description = exc.detail
+    elif isinstance(exc, RequestValidationError):
+        errors = exc.errors()
+        description = (
+            "\n".join(
+                e.get("msg", f"Failed to fetch validation error #{i + 1}")
+                for i, e in enumerate(errors)
+            )
+            if errors
+            else "The submitted data was invalid."
+        )
     else:
         description = str(exc)
 

--- a/frontend/shadow-cljs.edn
+++ b/frontend/shadow-cljs.edn
@@ -7,7 +7,6 @@
                 [devcards "0.2.6"]
                 [org.clojure/core.match "1.0.1"]
                 [clojure-interop/cljs-web-api "1.0.10"]
-                [lambdaisland/fetch "1.2.69"]
                 [clj-kondo "2022.05.31"]
                 [dev.weavejester/lein-cljfmt "0.12.0"]
                 [metosin/malli "0.14.0"]

--- a/frontend/src/app/common/state.cljs
+++ b/frontend/src/app/common/state.cljs
@@ -14,9 +14,28 @@
   (reset! error-title title)
   (reset! error-description description))
 
-(defn handle-validation-error [title description]
-  ;; Go back to "has files" state, let users fix
-  ;; validation errors
-  (reset! status nil)
-  (reset! error-title title)
-  (reset! error-description description))
+(defn handle-http-error
+  "Handle an HTTP error from cljs-ajax by setting error atoms with status code, phrase, and detail."
+  [error]
+  (let [http-status (:status error)
+        status-text (:status-text error)
+        detail (get-in error [:response :description])
+        title (str http-status " " status-text)]
+    (cond
+      (= http-status 0)
+      (handle-backend-error
+       "No response"
+       "The server did not respond. Please check your connection and try again.")
+
+      (not-empty detail)
+      (handle-backend-error title detail)
+
+      :else
+      (handle-backend-error title "An unexpected error occurred."))))
+
+(defn handle-validation-error
+  "Handle a form submission error. Displays the error but resets status
+   so the form remains editable."
+  [error]
+  (handle-http-error error)
+  (reset! status nil))

--- a/frontend/src/app/contribute/core.cljs
+++ b/frontend/src/app/contribute/core.cljs
@@ -1,6 +1,6 @@
 (ns app.contribute.core
   (:require
-   [lambdaisland.fetch :as fetch]
+   [ajax.core :refer [GET]]
    ["html-entities" :as html-entities]
    [app.helpers :refer
     [current-path
@@ -46,7 +46,8 @@
      files
      error-description
      error-title
-     how-to-fix]]))
+     how-to-fix
+     handle-http-error]]))
 
 (defn set-atoms
   "Set atoms to contain fields from `data` map.
@@ -80,16 +81,11 @@
   []
 
   (let [url (remove-trailing-slash (str "/frontend" (current-path)))]
-    (-> (fetch/get url {:accept :json :content-type :json})
-        (.then (fn [resp]
-                 (-> resp :body (js->clj :keywordize-keys true))))
-        (.then (fn [data]
-                 (if (:error data)
-                   (do
-                     (reset! status "error")
-                     (reset! error-title (:error data))
-                     (reset! error-description (:description data)))
-                   (set-atoms data)))))))
+    (GET url
+      :response-format :json
+      :keywords? true
+      :error-handler handle-http-error
+      :handler set-atoms)))
 
 (defn fetch-logs-upload
   "Fetch logs and other associated data from direct upload to the website."

--- a/frontend/src/app/contribute/events.cljs
+++ b/frontend/src/app/contribute/events.cljs
@@ -1,7 +1,7 @@
 (ns app.contribute.events
   (:require
    [clojure.set :refer [rename-keys]]
-   [lambdaisland.fetch :as fetch]
+   [ajax.core :refer [POST]]
    [app.helpers :refer
     [current-path
      remove-trailing-slash
@@ -15,11 +15,10 @@
      ok-status]]
    [app.common.state :refer
     [status
-     error-title
-     error-description
      fail-reason
      how-to-fix
-     files]]))
+     files
+     handle-validation-error]]))
 
 (defn submit-form
   "Render annotation submission form with retrieved logs"
@@ -53,20 +52,15 @@
               :container_file @container}]
 
     (reset! status "submitting")
-    (-> (fetch/post url {:accept :json :content-type :json :body body})
-        (.then (fn [resp] (-> resp :body (js->clj :keywordize-keys true))))
-        (.then (fn [data]
-                 (cond (:error data)
-                       (do
-                         (reset! error-title (:error data))
-                         (reset! error-description (:description data))
-                         ;; go back to "has files" state, let users fix
-                         ;; validation errors
-                         (reset! status nil))
-
-                       (= (:status data) "ok") ((reset! status "submitted")
-                                                (reset! ok-status data))
-                       :else nil))))))
+    (POST url
+      :params body
+      :format :json
+      :response-format :json
+      :keywords? true
+      :error-handler handle-validation-error
+      :handler (fn [data]
+                 (reset! status "submitted")
+                 (reset! ok-status data)))))
 
 (defn on-how-to-fix-textarea-change [target]
   (reset! how-to-fix (.-value target)))

--- a/frontend/src/app/contribute/landing.cljs
+++ b/frontend/src/app/contribute/landing.cljs
@@ -3,7 +3,7 @@
             [clojure.string :as str]
             [cljs.core.match :refer-macros [match]]
             [app.validation :refer [validate]]
-            [lambdaisland.fetch :as fetch]
+            [ajax.core :refer [GET]]
             [app.components.jumbotron :refer [render-error]]
             [app.common.provider-forms :as pf]
             [app.helpers :refer
@@ -21,15 +21,13 @@
 (def error (r/atom nil))
 
 (defn fetch-stats-backend []
-  (-> (fetch/get "/stats" {:accept :json :content-type :json})
-      (.then (fn [resp]
-               (-> resp :body (js->clj :keywordize-keys true))))
-      (.then (fn [resp]
-               (reset! backend-stats resp)))
-      (.catch (fn [err]
-               (reset! error {
-                  :title "Error fetching server statistics"
-                  :description err })))))
+  (GET "/stats"
+    :response-format :json
+    :keywords? true
+    :handler (fn [data] (reset! backend-stats data))
+    :error-handler (fn [_]
+                     (reset! error {:title "Error fetching server statistics"
+                                    :description "Could not load statistics from the server."}))))
 
 (defn on-submit [event]
   (.preventDefault event)

--- a/frontend/src/app/core.cljs
+++ b/frontend/src/app/core.cljs
@@ -6,26 +6,31 @@
             [app.review.core :refer [review init-data-review]]
             [app.explain.core :refer [explain-page init-explain]]))
 
-(defn ^:dev/after-load render
-  "Render the toplevel component for this app."
+(def routes
+  "Map of DOM element IDs to their view components and init functions.
+   The backend template determines which element exists on the page."
+  {"app-homepage"           {:view explain-page    :init init-explain}
+   "app-contribute-landing" {:view contribute-landing :init init-contribute-landing}
+   "app-contribute"         {:view contribute      :init init-data}
+   "app-review"             {:view review          :init init-data-review}
+   "app-explain"            {:view explain-page    :init init-explain}})
+
+(defn find-active-route
+  "Find the first route whose DOM element exists on the page."
   []
-  ;; This is not the standard way of doing this, we should probably use some
-  ;; router. But it is good enough for now.
-  (let [routes [["app-homepage" explain-page init-explain]
-                ["app-contribute-landing" contribute-landing init-contribute-landing]
-                ["app-contribute" contribute init-data]
-                ["app-review" review init-data-review]
-                ["app-explain" explain-page init-explain]]
-        route (->> routes
-                   (filter (fn [x] (.getElementById js/document (first x))))
-                   first)
-        name (nth route 0)
-        view (nth route 1)
-        init (nth route 2)]
-    (when init (init))
-    (r/render [view] (.getElementById js/document name))))
+  (->> routes
+       (filter (fn [[id]] (.getElementById js/document id)))
+       first))
+
+(defn ^:dev/after-load render
+  "Render the active route's view. Called on hot-reload without re-running init."
+  []
+  (when-let [[id {:keys [view]}] (find-active-route)]
+    (r/render [view] (.getElementById js/document id))))
 
 (defn ^:export main
-  "Run application startup logic."
+  "Application entrypoint. Runs init for the active route, then renders."
   []
+  (when-let [[_ {:keys [init]}] (find-active-route)]
+    (when init (init)))
   (render))

--- a/frontend/src/app/explain/core.cljs
+++ b/frontend/src/app/explain/core.cljs
@@ -306,33 +306,24 @@
 ;; --- Main component ---
 
 (defn explain-page []
-  (let [query-url (query-params-get "url")
-        ppath (provider-path)]
-    (cond
-      (= @status "error")
-      (render-error @error-title @error-description)
+  (cond
+    (= @status "error")
+    (render-error @error-title @error-description)
 
-      (= @status "waiting")
-      (loading-screen "Getting a response from the server")
+    (= @status "waiting")
+    (loading-screen "Getting a response from the server")
 
-      ;; Old ?url= flow: backward compatible
-      (and query-url (not= @status "ok"))
-      (do
-        (send query-url)
-        (loading-screen "Getting a response from the server"))
+    @atoms/form
+    (two-column-layout)
 
-      ;; Provider path: e.g. /explain/copr/123/fedora-39-x86_64
-      (and ppath (not= @status "ok"))
-      (do
-        (send-provider (str "/frontend/explain/" ppath))
-        (loading-screen "Getting a response from the server"))
-
-      @atoms/form
-      (two-column-layout)
-
-      :else
-      (explain-input))))
+    :else
+    (explain-input)))
 
 (defn init-explain []
   (reset! status nil)
-  (reset! atoms/form nil))
+  (reset! atoms/form nil)
+  (let [query-url (query-params-get "url")
+        ppath (provider-path)]
+    (cond
+      query-url (send query-url)
+      ppath (send-provider (str "/frontend/explain/" ppath)))))

--- a/frontend/src/app/explain/core.cljs
+++ b/frontend/src/app/explain/core.cljs
@@ -13,7 +13,8 @@
     [status
      error-description
      error-title
-     handle-backend-error]]))
+     handle-backend-error
+     handle-http-error]]))
 
 (def InputSchema
   [:map {:closed true}
@@ -48,11 +49,7 @@
           :response-format :json
           :keywords? true
 
-          :error-handler
-          (fn [error]
-            (handle-backend-error
-             (:error (:response error))
-             (:description (:response error))))
+          :error-handler handle-http-error
 
           :handler
           (fn [data]
@@ -293,11 +290,7 @@
     :response-format :json
     :keywords? true
 
-    :error-handler
-    (fn [error]
-      (handle-backend-error
-       (:error (:response error))
-       (:description (:response error))))
+    :error-handler handle-http-error
 
     :handler
     (fn [data]

--- a/frontend/src/app/review/core.cljs
+++ b/frontend/src/app/review/core.cljs
@@ -43,6 +43,7 @@
      status
      files
      handle-backend-error
+     handle-http-error
      handle-validation-error]]))
 
 (def InputSchema
@@ -131,11 +132,7 @@
     :response-format :json
     :keywords? true
 
-    :error-handler
-    (fn [error]
-      (handle-backend-error
-       (:error (:response error))
-       (:description (:response error))))
+    :error-handler handle-http-error
 
     :handler
     (fn [data]
@@ -171,11 +168,7 @@
        :format :json
        :keywords? true
 
-       :error-handler
-       (fn [error]
-         (handle-validation-error
-          (:error (:response error))
-          (:description (:response error))))
+       :error-handler handle-validation-error
 
        :handler
        (fn [_]


### PR DESCRIPTION
Fix HTTP error displaying (display status code, phrase and description). Also sync all error handlers to behave the same.
Was able to remove `lambdaisland.fetch` dependency - since `ajax.core` can access error phrases naturally for better error display - this also leads to somewhat cleaner code.

Deduplicated some information from exceptions etc.
Also includes some minor fixes.

Note: It seems that the initial issue with error displaying was partly addressed by https://github.com/fedora-copr/logdetective-website/pull/377

Since I know very little about Clojure JS, this PR is mostly:
Assisted-by: Claude Sonnet 4.6

<img width="729" height="351" alt="image" src="https://github.com/user-attachments/assets/5daf7776-6a7a-497c-9eaa-aa3278a02df5" />
