### PR TITLE
Limit upload size of artifacts

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: 3.12
+          python-version: 3.13
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: VCS Diff Lint
-        uses: fedora-copr/vcs-diff-lint-action@3fe529c95a55cf7d25d1ef73d53f790710c9a352 # v1.10.0
+        uses: fedora-copr/vcs-diff-lint-action@58d42564182d60919f728e8428d5858ca7ffcc05 # v1.19.0
         id: VCS_Diff_Lint
         with:
           subdirectory: backend

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -43,6 +43,11 @@ LOGDETECTIVE_MAX_KEEPALIVE_CONNECTIONS = int(
     os.environ.get("LOGDETECTIVE_MAX_KEEPALIVE_CONNECTIONS", 50)
 )
 
+# Direct upload size limit in Kilobytes
+LOG_DETECTIVE_MAX_ARTIFACT_SIZE = int(
+    os.environ.get("LOG_DETECTIVE_MAX_UPLOAD_SIZE", 10240)
+)
+
 
 class ProvidersEnum(StrEnum):
     packit = "packit"

--- a/backend/src/exceptions.py
+++ b/backend/src/exceptions.py
@@ -22,6 +22,6 @@ class MaximumArtifactSizeExceeded(HTTPException):
 
     def __init__(self) -> None:
         super().__init__(
-            status_code=HTTPStatus.CONTENT_TOO_LARGE,
+            status_code=HTTPStatus.CONTENT_TOO_LARGE,  # pylint: disable=E1101
             detail=f"Artifact exceeded maximum allowed size {LOG_DETECTIVE_MAX_ARTIFACT_SIZE} KB",
         )

--- a/backend/src/exceptions.py
+++ b/backend/src/exceptions.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 
 from fastapi import HTTPException
+from src.constants import LOG_DETECTIVE_MAX_ARTIFACT_SIZE
 
 
 class FetchError(HTTPException):
@@ -14,3 +15,13 @@ class FetchError(HTTPException):
 
 class NoDataFound(FetchError):
     pass
+
+
+class MaximumArtifactSizeExceeded(HTTPException):
+    """Artifacts exceeding maximum size can not be uploaded"""
+
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=HTTPStatus.CONTENT_TOO_LARGE,
+            detail=f"Artifact exceeded maximum allowed size {LOG_DETECTIVE_MAX_ARTIFACT_SIZE} KB",
+        )

--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -34,7 +34,9 @@ from src.constants import (
     DEFAULT_ROBOTS,
     STATIC_SOURCE_DIR,
     FETCH_TIMEOUT,
+    LOG_DETECTIVE_MAX_ARTIFACT_SIZE,
 )
+from src.exceptions import MaximumArtifactSizeExceeded
 
 
 @contextmanager
@@ -140,18 +142,36 @@ async def fetch_text(
     url: str, client: httpx.AsyncClient, timeout: float = FETCH_TIMEOUT, **kwargs
 ) -> httpx.Response:
     """
-    Fetch text content from URL with consistent UTF-8 encoding.
+    Fetch text content from URL with consistent UTF-8 encoding,
+    while checking size.
 
     Args:
         url: The URL to fetch
         timeout (default=FETCH_TIMEOUT): Request timeout in seconds to override httpx 5sec default
-        **kwargs: Additional arguments passed to AsyncClient.get()
+        **kwargs: Additional arguments passed to AsyncClient.stream()
 
     Returns:
         httpx.Response with encoding set to UTF-8
     """
-    response = await client.get(url, timeout=timeout, **kwargs)
-    response.encoding = "utf-8"
+
+    response_data = bytearray()
+    async with client.stream("GET", url=url, timeout=timeout, **kwargs) as stream:
+        try:
+            async for chunk in stream.aiter_bytes():
+                response_data += chunk
+                if len(response_data) > LOG_DETECTIVE_MAX_ARTIFACT_SIZE * 1024:
+                    raise MaximumArtifactSizeExceeded
+        except MaximumArtifactSizeExceeded:
+            await stream.aclose()
+            raise
+
+    response = httpx.Response(
+        status_code=stream.status_code,
+        text=response_data.decode("utf-8", errors="replace"),
+        default_encoding="utf-8",
+        headers=stream.headers,
+        request=stream.request,
+    )
     return response
 
 

--- a/backend/tests/unit/test_spells.py
+++ b/backend/tests/unit/test_spells.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 import httpx
+import pytest
 from src.constants import DEFAULT_ROBOTS
+from src.exceptions import MaximumArtifactSizeExceeded
 from src.spells import (
     ensure_text,
     fetch_text,
@@ -51,9 +53,63 @@ class TestFetchText:
         transport = httpx.MockTransport(_handler)
         client = httpx.AsyncClient(transport=transport)
         response = await fetch_text(url, client=client)
-
         assert response.encoding == "utf-8"
         assert response.text == czech_text
+
+    @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+    async def test_raises_on_oversized_response(self):
+        """Response exceeding size limit should raise MaximumArtifactSizeExceeded."""
+        url = "http://example.com/huge.log"
+        oversized_content = b"x" * 2048
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=oversized_content,
+                headers={"content-type": "text/plain"},
+            )
+
+        transport = httpx.MockTransport(_handler)
+        client = httpx.AsyncClient(transport=transport)
+        with patch("src.spells.LOG_DETECTIVE_MAX_ARTIFACT_SIZE", 1):
+            with pytest.raises(MaximumArtifactSizeExceeded):
+                await fetch_text(url, client=client)
+
+    async def test_accepts_response_within_limit(self):
+        """Response within size limit should not raise."""
+        url = "http://example.com/small.log"
+        small_content = "x" * 512
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=small_content.encode("utf-8"),
+                headers={"content-type": "text/plain"},
+            )
+
+        transport = httpx.MockTransport(_handler)
+        client = httpx.AsyncClient(transport=transport)
+        with patch("src.spells.LOG_DETECTIVE_MAX_ARTIFACT_SIZE", 1):
+            response = await fetch_text(url, client=client)
+            assert response.text == small_content
+
+    async def test_accepts_response_at_exact_limit(self):
+        """Response exactly at the size limit should not raise."""
+        url = "http://example.com/exact.log"
+        exact_content = "x" * 1024
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                content=exact_content.encode("utf-8"),
+                headers={"content-type": "text/plain"},
+            )
+
+        transport = httpx.MockTransport(_handler)
+        client = httpx.AsyncClient(transport=transport)
+        with patch("src.spells.LOG_DETECTIVE_MAX_ARTIFACT_SIZE", 1):
+            response = await fetch_text(url, client=client)
+            assert response.text == exact_content
 
 
 class TestJsonFileIO:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a configurable maximum size when fetching remote text.
  * Requests exceeding the limit now fail early with an HTTP 413 “content too large” error that includes the configured maximum (in KB).
  * Responses at or below the limit download and process normally.
* **Tests**
  * Added async unit tests for oversized payloads, under-limit payloads, and payloads exactly at the limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->