### PR TITLE
Add since parameter to /download to obtain only the latest submissions

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -12,7 +12,7 @@ from urllib import parse
 
 import httpx
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import (
     HTMLResponse,
@@ -32,6 +32,7 @@ from src.constants import (
     COPR_BUILD_URL,
     KOJI_BUILD_URL,
     OBS_BUILD_URL,
+    DOWNLOAD_SINCE_MAX_DAYS,
     FEEDBACK_DIR,
     REVIEWS_DIR,
     SERVER_URL,
@@ -825,8 +826,18 @@ async def store_random_review(feedback_input: Request) -> OkResponse:
     return OkResponse.from_id(file_name, our_server)
 
 
+def _validated_since(since: date | None = None) -> date | None:
+    if since is not None and (date.today() - since).days > DOWNLOAD_SINCE_MAX_DAYS:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"The 'since' date must be within the last"
+            f" {DOWNLOAD_SINCE_MAX_DAYS} days",
+        )
+    return since
+
+
 @app.get("/download")
-def download_results(since: date | None = None):
+def download_results(since: date | None = Depends(_validated_since)):
     """
     Download results as a tar.gz archive.
 

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -4,7 +4,7 @@ import uuid
 from asyncio import create_task, gather
 from base64 import b64decode
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import date, datetime
 from http import HTTPStatus
 from pathlib import Path
 from typing import Optional
@@ -20,10 +20,12 @@ from fastapi.responses import (
     FileResponse,
     RedirectResponse,
     PlainTextResponse,
+    Response,
 )
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
+from starlette.background import BackgroundTask
 from starlette.exceptions import HTTPException
 
 from src.constants import (
@@ -61,6 +63,7 @@ from src.schema import (
     schema_inp_to_out,
 )
 from src.spells import (
+    build_filtered_archive,
     find_file_by_name,
     get_logger,
     start_sentry,
@@ -823,16 +826,30 @@ async def store_random_review(feedback_input: Request) -> OkResponse:
 
 
 @app.get("/download")
-def download_results():
+def download_results(since: date | None = None):
     """
-    Download all results we have as a tar.gz archive.
+    Download results as a tar.gz archive.
 
-    The archive is pre-built daily by the create-archive CronJob and stored at
-    /persistent/results-YYYY-MM-DD.tar.gz. This endpoint just serves the most
-    recent one directly, avoiding a long blocking tar creation on each request.
+    Without ``since``, serves the most recent pre-built daily archive.
+    With ``since=YYYY-MM-DD``, dynamically creates an archive containing
+    only result date-folders on or after that date.  Returns 204 when the
+    filtered archive would be empty.
     """
     if not FEEDBACK_DIR:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="No data found")
+
+    if since is not None:
+        archive_path = build_filtered_archive(FEEDBACK_DIR, since)
+        if archive_path is None:
+            return Response(status_code=HTTPStatus.NO_CONTENT)
+
+        filename = f"results-since-{since.isoformat()}.tar.gz"
+        LOGGER.info("Serving filtered dataset archive: %s", filename)
+        return FileResponse(
+            archive_path,
+            filename=filename,
+            background=BackgroundTask(os.unlink, archive_path),
+        )
 
     storage_dir = Path(FEEDBACK_DIR).parent
     archives = sorted(

--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -9,6 +9,10 @@ OBS_BUILD_URL = "https://build.opensuse.org/package/show/{0}/{1}"
 FEEDBACK_DIR = os.environ.get("FEEDBACK_DIR", "/persistent/results")
 REVIEWS_DIR = os.environ.get("REVIEWS_DIR", "/persistent/reviews")
 
+# Maximum number of days allowed for the 'since' parameter in the /download endpoint.
+# This is to prevent excessive data retrieval.
+DOWNLOAD_SINCE_MAX_DAYS = 90
+
 # Gunicorn worker timeout (files/gunicorn.conf.py) must be > this value.
 # Note: > 90 % analysis requests finish within 30 seconds as of June 2026.
 LOGDETECTIVE_READ_TIMEOUT = float(os.environ.get("LOGDETECTIVE_READ_TIMEOUT", 600))

--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -6,8 +6,10 @@ import json
 import logging
 import os
 import shutil
+import tarfile
 import tempfile
 from contextlib import contextmanager
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Iterator, Optional
@@ -277,6 +279,51 @@ def sanitize_uploaded_schema(input_schema: FeedbackSchema) -> FeedbackSchema:
         )
 
     return result
+
+
+def _try_parse_date(name: str) -> date | None:
+    try:
+        return date.fromisoformat(name)
+    except ValueError:
+        return None
+
+
+def build_filtered_archive(feedback_dir: str, since_date: date) -> Path | None:
+    """
+    Build a tar.gz archive containing only result date-folders from since_date onward.
+
+    Returns the path to the temporary archive file, or None if no data matched.
+    The caller is responsible for deleting the file after use.
+    """
+    feedback_path = Path(feedback_dir)
+    if not feedback_path.is_dir():
+        return None
+
+    result_dirs = sorted(
+        d
+        for d in feedback_path.iterdir()
+        if d.is_dir()
+        and (parsed := _try_parse_date(d.name)) is not None
+        and parsed >= since_date
+        and any(f.is_file() for f in d.rglob("*.json"))
+    )
+
+    if not result_dirs:
+        return None
+
+    fd, tmp_name = tempfile.mkstemp(suffix=".tar.gz")
+    os.close(fd)
+    success = False
+    try:
+        with tarfile.open(tmp_name, "w:gz") as tar:
+            for d in result_dirs:
+                tar.add(d, arcname=f"results/results/{d.name}")
+        success = True
+    finally:
+        if not success:
+            os.unlink(tmp_name)
+
+    return Path(tmp_name)
 
 
 @lru_cache(maxsize=1)

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -6,6 +6,7 @@ import json
 import os
 import tarfile
 from base64 import b64encode
+from datetime import date
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import httpx
@@ -645,8 +646,14 @@ class TestDownloadEndpoint:
         resp = client.get("/download")
         assert resp.status_code == 404
 
-    def test_download_since_returns_filtered_archive(self, tmp_path, monkeypatch):
+    @patch("src.api.date")
+    def test_download_since_returns_filtered_archive(
+        self, mock_date, tmp_path, monkeypatch
+    ):
         """Return a filtered archive for /download?since=<date> and valid date."""
+
+        mock_date.today.return_value = date(2026, 7, 15)
+        mock_date.fromisoformat = date.fromisoformat
 
         results_dir = tmp_path / "results"
         (results_dir / "2026-07-10" / "copr" / "123").mkdir(parents=True)
@@ -669,8 +676,14 @@ class TestDownloadEndpoint:
         assert any("2026-07-12" in n for n in names)
         assert not any("2026-07-05" in n for n in names)
 
-    def test_download_since_includes_boundary_date(self, tmp_path, monkeypatch):
+    @patch("src.api.date")
+    def test_download_since_includes_boundary_date(
+        self, mock_date, tmp_path, monkeypatch
+    ):
         """Make sure that results from `since` date are included."""
+
+        mock_date.today.return_value = date(2026, 7, 15)
+        mock_date.fromisoformat = date.fromisoformat
 
         results_dir = tmp_path / "results"
         (results_dir / "2026-07-10" / "copr" / "123").mkdir(parents=True)
@@ -690,8 +703,14 @@ class TestDownloadEndpoint:
         assert any("2026-07-10" in n for n in names)
         assert not any("2026-07-09" in n for n in names)
 
-    def test_download_since_skips_empty_and_non_json_dirs(self, tmp_path, monkeypatch):
+    @patch("src.api.date")
+    def test_download_since_skips_empty_and_non_json_dirs(
+        self, mock_date, tmp_path, monkeypatch
+    ):
         """Return 204 when matching date dirs exist but contain no JSON files."""
+
+        mock_date.today.return_value = date(2026, 7, 15)
+        mock_date.fromisoformat = date.fromisoformat
 
         results_dir = tmp_path / "results"
         # Empty directory
@@ -705,9 +724,13 @@ class TestDownloadEndpoint:
         resp = client.get("/download", params={"since": "2026-07-10"})
         assert resp.status_code == 204
 
-    def test_download_since_empty_returns_204(self, tmp_path, monkeypatch):
+    @patch("src.api.date")
+    def test_download_since_empty_returns_204(self, mock_date, tmp_path, monkeypatch):
         """Return 204 for /download?since=<date> if no results exist since that date.
         This also applies if the date is in the future."""
+
+        mock_date.today.return_value = date(2026, 7, 15)
+        mock_date.fromisoformat = date.fromisoformat
 
         results_dir = tmp_path / "results"
         (results_dir / "2026-07-01" / "copr" / "123").mkdir(parents=True)
@@ -726,6 +749,16 @@ class TestDownloadEndpoint:
         client = TestClient(app)
         resp = client.get("/download", params={"since": "not-a-date"})
         assert resp.status_code == 422
+
+    def test_download_since_too_old_returns_400(self, tmp_path, monkeypatch):
+        """Return 400 if the since date is older than DOWNLOAD_SINCE_MAX_DAYS."""
+
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(tmp_path / "results"))
+
+        client = TestClient(app)
+        resp = client.get("/download", params={"since": "2020-01-01"})
+        assert resp.status_code == 400
+        assert "The 'since' date must be within" in resp.json()["description"]
 
 
 def test_our_server_url(tmp_path):

--- a/backend/tests/unit/test_api.py
+++ b/backend/tests/unit/test_api.py
@@ -4,11 +4,13 @@ Test the API endpoints.
 
 import json
 import os
+import tarfile
 from base64 import b64encode
 from unittest.mock import patch, AsyncMock, MagicMock
 
 import httpx
 import pytest
+from fastapi.testclient import TestClient
 from starlette.exceptions import HTTPException
 
 from src.api import app
@@ -612,8 +614,122 @@ class TestCheckLogUrls:
         assert "connection refused" in exc_info.value.detail
 
 
+class TestDownloadEndpoint:
+    """Tests for the /download endpoint - with and without `since` parameter."""
+
+    def test_download_serves_prebuilt_archive(self, tmp_path, monkeypatch):
+        """Test that the /download endpoint serves a prebuilt archive if it exists.
+        Archives sit in the parent of FEEDBACK_DIR (i.e. /persistent/)"""
+
+        results_dir = str(tmp_path / "results")
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", results_dir)
+        archive = tmp_path / "results-2026-07-14.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            dummy = tmp_path / "dummy.txt"
+            dummy.write_text("hello")
+            tar.add(dummy, arcname="results/results/dummy.txt")
+
+        client = TestClient(app)
+        resp = client.get("/download")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/x-tar"
+
+    def test_download_no_archive_returns_404(self, tmp_path, monkeypatch):
+        """Return 404 for /download if no archive exists."""
+
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(results_dir))
+
+        client = TestClient(app)
+        resp = client.get("/download")
+        assert resp.status_code == 404
+
+    def test_download_since_returns_filtered_archive(self, tmp_path, monkeypatch):
+        """Return a filtered archive for /download?since=<date> and valid date."""
+
+        results_dir = tmp_path / "results"
+        (results_dir / "2026-07-10" / "copr" / "123").mkdir(parents=True)
+        (results_dir / "2026-07-10" / "copr" / "123" / "a.json").write_text("{}")
+        (results_dir / "2026-07-12" / "copr" / "456").mkdir(parents=True)
+        (results_dir / "2026-07-12" / "copr" / "456" / "b.json").write_text("{}")
+        (results_dir / "2026-07-05" / "koji" / "789").mkdir(parents=True)
+        (results_dir / "2026-07-05" / "koji" / "789" / "c.json").write_text("{}")
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(results_dir))
+
+        client = TestClient(app)
+        resp = client.get("/download", params={"since": "2026-07-10"})
+        assert resp.status_code == 200
+
+        archive_path = tmp_path / "response.tar.gz"
+        archive_path.write_bytes(resp.content)
+        with tarfile.open(archive_path, "r:gz") as tar:
+            names = tar.getnames()
+        assert any("2026-07-10" in n for n in names)
+        assert any("2026-07-12" in n for n in names)
+        assert not any("2026-07-05" in n for n in names)
+
+    def test_download_since_includes_boundary_date(self, tmp_path, monkeypatch):
+        """Make sure that results from `since` date are included."""
+
+        results_dir = tmp_path / "results"
+        (results_dir / "2026-07-10" / "copr" / "123").mkdir(parents=True)
+        (results_dir / "2026-07-10" / "copr" / "123" / "a.json").write_text("{}")
+        (results_dir / "2026-07-09" / "copr" / "456").mkdir(parents=True)
+        (results_dir / "2026-07-09" / "copr" / "456" / "b.json").write_text("{}")
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(results_dir))
+
+        client = TestClient(app)
+        resp = client.get("/download", params={"since": "2026-07-10"})
+        assert resp.status_code == 200
+
+        archive_path = tmp_path / "response.tar.gz"
+        archive_path.write_bytes(resp.content)
+        with tarfile.open(archive_path, "r:gz") as tar:
+            names = tar.getnames()
+        assert any("2026-07-10" in n for n in names)
+        assert not any("2026-07-09" in n for n in names)
+
+    def test_download_since_skips_empty_and_non_json_dirs(self, tmp_path, monkeypatch):
+        """Return 204 when matching date dirs exist but contain no JSON files."""
+
+        results_dir = tmp_path / "results"
+        # Empty directory
+        (results_dir / "2026-07-10").mkdir(parents=True)
+        # Directory with only non-JSON files
+        (results_dir / "2026-07-11" / "copr" / "123").mkdir(parents=True)
+        (results_dir / "2026-07-11" / "copr" / "123" / "notes.txt").write_text("hello")
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(results_dir))
+
+        client = TestClient(app)
+        resp = client.get("/download", params={"since": "2026-07-10"})
+        assert resp.status_code == 204
+
+    def test_download_since_empty_returns_204(self, tmp_path, monkeypatch):
+        """Return 204 for /download?since=<date> if no results exist since that date.
+        This also applies if the date is in the future."""
+
+        results_dir = tmp_path / "results"
+        (results_dir / "2026-07-01" / "copr" / "123").mkdir(parents=True)
+        (results_dir / "2026-07-01" / "copr" / "123" / "a.json").write_text("{}")
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(results_dir))
+
+        client = TestClient(app)
+        resp = client.get("/download", params={"since": "2099-01-01"})
+        assert resp.status_code == 204
+
+    def test_download_since_invalid_date_returns_422(self, tmp_path, monkeypatch):
+        """Return 422 for /download?since=<date> if the date is invalid."""
+
+        monkeypatch.setattr("src.api.FEEDBACK_DIR", str(tmp_path / "results"))
+
+        client = TestClient(app)
+        resp = client.get("/download", params={"since": "not-a-date"})
+        assert resp.status_code == 422
+
+
 def test_our_server_url(tmp_path):
-    from fastapi.testclient import TestClient
+    """Test that the /frontend/contribute/copr endpoint returns URLs with the correct base URL."""
 
     client = TestClient(app)
     os.environ["FEEDBACK_DIR"] = str(tmp_path / "results")


### PR DESCRIPTION
This change is required in order to make vector db populate/update script have as little load as possible and to reduce the data transfer between LD server and website.

The `since` parameter is supposed to be iso date format `YYYY-MM-DD`.
If `since` is undefined, the original behavior is used.

I also added a few unit tests.

- `?since=2026-07-01` will also include all json files within results/2026-07-01 in the archive
- if there is no json that satisfies since (also when the date is in the future), `204 No Content` and empty response are returned
- if the date is somehow malformed or doesn't exist, `422 Unprocessable Content` is returned
- at this point we only add json files into the archive - if some `results/YYYY-MM-DD` folder does not contain any json files, it's not included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added optional `since` date filtering to result downloads.
  * When `since` is provided, matching results are packaged on-demand into a downloadable `tar.gz` with a date-based name.
* **Bug Fixes**
  * Improved responses: returns **204 No Content** when no matching data (or matching folders without JSON files) is found.
  * Enforces `since` to be within the last **90 days**.
* **Tests**
  * Expanded `/download` unit tests to cover serving existing archives, filtered tarball contents (including boundary dates), and all key status codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->