### PR TITLE
Fix double decompression in fetch_text()

### DIFF
--- a/backend/src/spells.py
+++ b/backend/src/spells.py
@@ -155,7 +155,6 @@ async def fetch_text(
     Returns:
         httpx.Response with encoding set to UTF-8
     """
-
     response_data = bytearray()
     async with client.stream("GET", url=url, timeout=timeout, **kwargs) as stream:
         try:
@@ -167,11 +166,19 @@ async def fetch_text(
             await stream.aclose()
             raise
 
+    headers = dict(stream.headers)
+    # aiter_bytes() already decompresses; drop the header so the Response
+    # constructor doesn't attempt to decompress again.
+    headers.pop("content-encoding", None)
+    # removing content-length forces recalculation during Response creation,
+    # otherwise we have the incomplete length (of last chunk)
+    headers.pop("content-length", None)
+
     response = httpx.Response(
         status_code=stream.status_code,
         text=response_data.decode("utf-8", errors="replace"),
         default_encoding="utf-8",
-        headers=stream.headers,
+        headers=headers,
         request=stream.request,
     )
     return response


### PR DESCRIPTION
Changes to limit upload size introduced this bug (at least for copr and URL contributions):
<img width="973" height="500" alt="image" src="https://github.com/user-attachments/assets/d0fde8e5-29fd-471b-9412-3338aaa6826b" />

The issue is that `aiter_bytes()` already does decompression and `Content-Encoding` header during `httpx.Response` creation enforces it again, leading to the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented streamed spell content from being decompressed multiple times.
  * Improved streamed text handling by sanitizing response headers and avoiding incorrect content-length values.
  * Continued to display streamed text safely when it contains invalid characters by replacing problematic bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->